### PR TITLE
Feature/fiscal comment

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -29,6 +29,7 @@
         "data/partner_profile_data.xml",
         "data/l10n_br_fiscal_server_action.xml",
         "data/ir_cron.xml",
+        "data/l10n_br_fiscal_comment_data.xml",
 
         # Wizards
 

--- a/l10n_br_fiscal/data/l10n_br_fiscal_comment_data.xml
+++ b/l10n_br_fiscal/data/l10n_br_fiscal_comment_data.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="0">
+    <record id="fiscal_comment_dummy" model="l10n_br_fiscal.comment">
+        <field name="name">Usuário emissor</field>
+        <field name="comment">Documento emitido por: ${(doc.user_id.name)}</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document</field>
+    </record>
+
+    <record id="fiscal_line_comment_dummy" model="l10n_br_fiscal.comment">
+        <field name="name">Total estimado dos impostos</field>
+        <field name="comment">Val Aprox Tributos Federal ${format_amount(doc.amount_tax)}</field>
+        <field name="comment_type">fiscal</field>
+        <field name="object">l10n_br_fiscal.document.line</field>
+    </record>
+</odoo>

--- a/l10n_br_fiscal/demo/fiscal_operation_demo.xml
+++ b/l10n_br_fiscal/demo/fiscal_operation_demo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="0">
+
+    <record id="l10n_br_fiscal.fo_venda" model="l10n_br_fiscal.operation">
+        <field name="comment_ids" eval="[(6,0,[ref('l10n_br_fiscal.fiscal_comment_dummy')])]"/>
+    </record>
+
+    <record id="l10n_br_fiscal.fo_venda_venda" model="l10n_br_fiscal.operation.line">
+        <field name="comment_ids" eval="[(6,0,[ref('l10n_br_fiscal.fiscal_line_comment_dummy')])]"/>
+    </record>
+
+</odoo>

--- a/l10n_br_fiscal/hooks.py
+++ b/l10n_br_fiscal/hooks.py
@@ -6,7 +6,6 @@ from odoo import tools
 
 def post_init_hook(cr, registry):
     """Import XML data to change core data"""
-    from odoo.tools import convert_file
 
     files = [
         "data/l10n_br_fiscal.cnae.csv",
@@ -44,6 +43,7 @@ def post_init_hook(cr, registry):
             "demo/product_demo.xml",
             "demo/partner_demo.xml",
             "demo/l10n_br_fiscal_document_demo.xml",
+            "demo/fiscal_operation_demo.xml",
         ]
 
         for f in demofiles:

--- a/l10n_br_fiscal/hooks.py
+++ b/l10n_br_fiscal/hooks.py
@@ -6,6 +6,7 @@ from odoo import tools
 
 def post_init_hook(cr, registry):
     """Import XML data to change core data"""
+    from odoo.tools import convert_file
 
     files = [
         "data/l10n_br_fiscal.cnae.csv",

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -26,7 +26,7 @@ class Comment(models.Model):
         string="Comment",
         required=True)
 
-    processed_comment = fields.Text(string="Processed Comment")
+    test_comment = fields.Text(string="Test Comment")
 
     comment_type = fields.Selection(
         selection=COMMENT_TYPE,
@@ -89,7 +89,7 @@ class Comment(models.Model):
     # We'll call this function when setting the variables env below
     def format_amount(self, env, amount, currency):
         fmt = "%.{0}f".format(currency.decimal_places)
-        lang = env['res.lang']._lang_get(env.context.get('lang') or 'en_US')
+        lang = env['res.lang']._lang_get('pt_BR')
 
         formatted_amount = lang.format(
             fmt, currency.round(amount), grouping=True, monetary=True).replace(
@@ -138,9 +138,9 @@ class Comment(models.Model):
                 *a, **kw),
             # adding format amount
             # now we can format values like currency on fiscal observation
-            'format_amount': lambda amount,
-                                    context=self._context: self.format_amount(
-                self.env, amount, self.env.ref('base.BRL')),
+            'format_amount':
+                lambda amount, context=self._context: self.format_amount(
+                    self.env, amount, self.env.ref('base.BRL')),
         })
         mako_safe_env = copy.copy(mako_template_env)
         mako_safe_env.autoescape = False
@@ -152,10 +152,10 @@ class Comment(models.Model):
             result += render_result + '\n'
         return result
 
-    def action_compute_message(self):
+    def action_test_message(self):
         vals = {
             'user': self.env.user,
             'ctx': self._context,
             'doc': self.object_id
         }
-        self.processed_comment = self.compute_message(vals)
+        self.test_comment = self.compute_message(vals)

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -114,7 +114,7 @@ class Comment(models.Model):
 
         return u'{pre}{0}{post}'.format(formatted_amount, pre=pre, post=post)
 
-    def action_compute_message(self):
+    def compute_message(self, vals):
         from jinja2.sandbox import SandboxedEnvironment
         mako_template_env = SandboxedEnvironment(
             block_start_string="<%",
@@ -155,17 +155,16 @@ class Comment(models.Model):
         mako_safe_env.autoescape = False
 
         result = ''
-        for item in self.document:
-            template = mako_safe_env.from_string(tools.ustr(self.comment))
-            variables = self._get_variables_msg()
-            render_result = template.render(variables)
+        for record in self:
+            template = mako_safe_env.from_string(tools.ustr(record.comment))
+            render_result = template.render(vals)
             result += render_result + '\n'
-        self.processed_comment = result
-        return
+        return result
 
-    def _get_variables_msg(self):
-        return {
+    def action_compute_message(self):
+        vals = {
             'user': self.env.user,
             'ctx': self._context,
             'doc': self.object_id
         }
+        self.processed_comment = self.compute_message(vals)

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -6,8 +6,6 @@ from odoo import api, fields, models, tools
 from dateutil.relativedelta import relativedelta
 from odoo.osv import expression
 from datetime import datetime
-from odoo.exceptions import UserError
-import re
 
 from ..constants.fiscal import COMMENT_TYPE, COMMENT_TYPE_DEFAULT
 
@@ -140,10 +138,9 @@ class Comment(models.Model):
                 *a, **kw),
             # adding format amount
             # now we can format values like currency on fiscal observation
-            # TODO: get currency from fiscal document instead of using 'self.env.ref('base.BRL')'
             'format_amount': lambda amount,
-                                    context=self._context: self.format_amount(self.env, amount,
-                                                                              self.env.ref('base.BRL')),
+                                    context=self._context: self.format_amount(
+                self.env, amount, self.env.ref('base.BRL')),
         })
         mako_safe_env = copy.copy(mako_template_env)
         mako_safe_env.autoescape = False

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -1,8 +1,13 @@
 # Copyright (C) 2019  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import copy
 
-from odoo import api, fields, models
+from odoo import api, fields, models, tools
+from dateutil.relativedelta import relativedelta
 from odoo.osv import expression
+from datetime import datetime
+from odoo.exceptions import UserError
+import re
 
 from ..constants.fiscal import COMMENT_TYPE, COMMENT_TYPE_DEFAULT
 
@@ -13,9 +18,13 @@ class Comment(models.Model):
     _order = "sequence"
     _rec_name = "comment"
 
-    sequence = fields.Integer(
-        string="Sequence",
-        default=10)
+    document = fields.Many2one(
+        comodel_name="l10n_br_fiscal.document",
+        string="Documento",
+        required=False,
+    )
+
+    sequence = fields.Integer(string="Sequence", default=10)
 
     name = fields.Char(
         string="Name",
@@ -24,6 +33,8 @@ class Comment(models.Model):
     comment = fields.Text(
         string="Comment",
         required=True)
+
+    processed_comment = fields.Text(string="Processed Comment")
 
     comment_type = fields.Selection(
         selection=COMMENT_TYPE,
@@ -69,3 +80,92 @@ class Comment(models.Model):
             return name
 
         return [(r.id, "{}".format(truncate_name(r.name))) for r in self]
+
+    @api.multi
+    def object_selection_values(self):
+        return [('l10n_br_fiscal.document', "Fiscal Document"),
+                ('l10n_br_fiscal.document.line', "Fiscal Document Line")]
+
+    object_id = fields.Reference(
+        string='Reference',
+        selection=lambda self: self.object_selection_values(),
+        ondelete="set null"
+    )
+
+    # format_amount function for fiscal observation
+    # This way we can format numbers in currency template on fiscal observation msg
+    # We'll call this function when setting the variables env below
+    def format_amount(self, env, amount, currency):
+        fmt = "%.{0}f".format(currency.decimal_places)
+        lang = env['res.lang']._lang_get(env.context.get('lang') or 'en_US')
+
+        formatted_amount = lang.format(
+            fmt, currency.round(amount), grouping=True, monetary=True).replace(
+            r' ', u'\N{NO-BREAK SPACE}').replace(
+            r'-', u'-\N{ZERO WIDTH NO-BREAK SPACE}')
+
+        pre = post = u''
+        if currency.position == 'before':
+            pre = u'{symbol}\N{NO-BREAK SPACE}'.format(
+                symbol=currency.symbol or '')
+        else:
+            post = u'\N{NO-BREAK SPACE}{symbol}'.format(
+                symbol=currency.symbol or '')
+
+        return u'{pre}{0}{post}'.format(formatted_amount, pre=pre, post=post)
+
+    def action_compute_message(self):
+        from jinja2.sandbox import SandboxedEnvironment
+        mako_template_env = SandboxedEnvironment(
+            block_start_string="<%",
+            block_end_string="%>",
+            variable_start_string="${",
+            variable_end_string="}",
+            comment_start_string="<%doc>",
+            comment_end_string="</%doc>",
+            line_statement_prefix="%",
+            line_comment_prefix="##",
+            trim_blocks=True,  # do not output newline after
+            autoescape=True,  # XML/HTML automatic escaping
+        )
+        mako_template_env.globals.update({
+            'str': str,
+            'datetime': datetime,
+            'len': len,
+            'abs': abs,
+            'min': min,
+            'max': max,
+            'sum': sum,
+            'filter': filter,
+            'map': map,
+            'round': round,
+            # dateutil.relativedelta is an old-style class and cannot be
+            # instanciated wihtin a jinja2 expression, so a lambda "proxy" is
+            # is needed, apparently.
+            'relativedelta': lambda *a, **kw: relativedelta.relativedelta(
+                *a, **kw),
+            # adding format amount
+            # now we can format values like currency on fiscal observation
+            # TODO: get currency from fiscal document instead of using 'self.env.ref('base.BRL')'
+            'format_amount': lambda amount,
+                                    context=self._context: self.format_amount(self.env, amount,
+                                                                              self.env.ref('base.BRL')),
+        })
+        mako_safe_env = copy.copy(mako_template_env)
+        mako_safe_env.autoescape = False
+
+        result = ''
+        for item in self.document:
+            template = mako_safe_env.from_string(tools.ustr(self.comment))
+            variables = self._get_variables_msg()
+            render_result = template.render(variables)
+            result += render_result + '\n'
+        self.processed_comment = result
+        return
+
+    def _get_variables_msg(self):
+        return {
+            'user': self.env.user,
+            'ctx': self._context,
+            'doc': self.object_id
+        }

--- a/l10n_br_fiscal/models/comment.py
+++ b/l10n_br_fiscal/models/comment.py
@@ -18,12 +18,6 @@ class Comment(models.Model):
     _order = "sequence"
     _rec_name = "comment"
 
-    document = fields.Many2one(
-        comodel_name="l10n_br_fiscal.document",
-        string="Documento",
-        required=False,
-    )
-
     sequence = fields.Integer(string="Sequence", default=10)
 
     name = fields.Char(

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -220,3 +220,9 @@ class Document(models.Model):
             old_state, new_state
         )
         self.document_comment()
+
+    @api.onchange("operation_id")
+    def _onchange_operation_id(self):
+        super(Document, self)._onchange_operation_id()
+        for comment_id in self.operation_id.comment_ids:
+            self.comment_ids += comment_id

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -28,6 +28,18 @@ class Document(models.Model):
 
     operation_type = fields.Selection(required=True, related=False)
 
+    comment_ids = fields.Many2many(
+        comodel_name="l10n_br_fiscal.comment",
+        relation="l10n_br_fiscal_document_comment_rel",
+        column1="document_id",
+        column2="comment_id",
+        string="Comments"
+    )
+
+    processed_comments = fields.Text(string="Processed Comments")
+
+    processed_line_comments = fields.Text(string="Processed Line Comments")
+
     operation_id = fields.Many2one(
         default=_default_operation,
         domain="[('state', '=', 'approved'), "
@@ -189,3 +201,22 @@ class Document(models.Model):
         action['domain'] = literal_eval(action['domain'])
         action['domain'].append(('id', '=', return_id.id))
         return action
+
+    def _document_comment_vals(self):
+        return {
+            'user': self.env.user,
+            'ctx': self._context,
+            'doc': self,
+        }
+
+    def document_comment(self):
+        for record in self:
+            record.processed_comments = record.processed_comments and record.processed_comments + ' - ' or ''
+            record.processed_comments += record.comment_ids.compute_message(record._document_comment_vals())
+            record.line_ids.document_comment()
+
+    def _exec_after_SITUACAO_EDOC_A_ENVIAR(self, old_state, new_state):
+        super(Document, self)._exec_before_SITUACAO_EDOC_A_ENVIAR(
+            old_state, new_state
+        )
+        self.document_comment()

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -211,8 +211,10 @@ class Document(models.Model):
 
     def document_comment(self):
         for record in self:
-            record.processed_comments = record.processed_comments and record.processed_comments + ' - ' or ''
-            record.processed_comments += record.comment_ids.compute_message(record._document_comment_vals())
+            record.processed_comments = record.processed_comments and \
+                                        record.processed_comments + ' - ' or ''
+            record.processed_comments += record.comment_ids.compute_message(
+                record._document_comment_vals())
             record.line_ids.document_comment()
 
     def _exec_after_SITUACAO_EDOC_A_ENVIAR(self, old_state, new_state):

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -36,9 +36,7 @@ class Document(models.Model):
         string="Comments"
     )
 
-    processed_comments = fields.Text(string="Processed Comments")
-
-    processed_line_comments = fields.Text(string="Processed Line Comments")
+    additional_data = fields.Text(string="Additional Data")
 
     operation_id = fields.Many2one(
         default=_default_operation,
@@ -211,9 +209,9 @@ class Document(models.Model):
 
     def document_comment(self):
         for record in self:
-            record.processed_comments = record.processed_comments and \
-                                        record.processed_comments + ' - ' or ''
-            record.processed_comments += record.comment_ids.compute_message(
+            record.additional_data = \
+                record.additional_data and record.additional_data + ' - ' or ''
+            record.additional_data += record.comment_ids.compute_message(
                 record._document_comment_vals())
             record.line_ids.document_comment()
 

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -57,3 +57,9 @@ class DocumentLine(models.Model):
                 record.additional_data and record.additional_data + ' - ' or ''
             record.additional_data += record.comment_ids.compute_message(
                 record._document_comment_vals())
+
+    @api.onchange("operation_line_id")
+    def _onchange_operation_line_id(self):
+        super(DocumentLine, self)._onchange_operation_line_id()
+        for comment_id in self.operation_line_id.comment_ids:
+            self.comment_ids += comment_id

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -20,6 +20,16 @@ class DocumentLine(models.Model):
         domain = [('state', '=', 'approved')]
         return domain
 
+    comment_ids = fields.Many2many(
+        comodel_name="l10n_br_fiscal.comment",
+        relation="l10n_br_fiscal_document_line_comment_rel",
+        column1="document_line_id",
+        column2="comment_id",
+        string="Comments"
+    )
+
+    processed_comments = fields.Text(string="Processed Comments")
+
     operation_id = fields.Many2one(
         default=_default_operation,
         domain=lambda self: self._operation_domain())
@@ -32,3 +42,16 @@ class DocumentLine(models.Model):
         selection=ICMS_BASE_TYPE,
         string="ICMS Base Type",
         default=ICMS_BASE_TYPE_DEFAULT)
+
+    def _document_comment_vals(self):
+        return {
+            'user': self.env.user,
+            'ctx': self._context,
+            'doc': self.document_id,
+            'item': self,
+        }
+
+    def document_comment(self):
+        for record in self.filtered('comment_ids'):
+            record.processed_comments = record.processed_comments and record.processed_comments + ' - ' or ''
+            record.processed_comments += record.comment_ids.compute_message(record._document_comment_vals())

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -28,7 +28,7 @@ class DocumentLine(models.Model):
         string="Comments"
     )
 
-    processed_comments = fields.Text(string="Processed Comments")
+    additional_data = fields.Text(string="Additional Data")
 
     operation_id = fields.Many2one(
         default=_default_operation,
@@ -53,7 +53,7 @@ class DocumentLine(models.Model):
 
     def document_comment(self):
         for record in self.filtered('comment_ids'):
-            record.processed_comments = record.processed_comments and \
-                                        record.processed_comments + ' - ' or ''
-            record.processed_comments += record.comment_ids.compute_message(
+            record.additional_data = \
+                record.additional_data and record.additional_data + ' - ' or ''
+            record.additional_data += record.comment_ids.compute_message(
                 record._document_comment_vals())

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -53,5 +53,7 @@ class DocumentLine(models.Model):
 
     def document_comment(self):
         for record in self.filtered('comment_ids'):
-            record.processed_comments = record.processed_comments and record.processed_comments + ' - ' or ''
-            record.processed_comments += record.comment_ids.compute_message(record._document_comment_vals())
+            record.processed_comments = record.processed_comments and \
+                                        record.processed_comments + ' - ' or ''
+            record.processed_comments += record.comment_ids.compute_message(
+                record._document_comment_vals())

--- a/l10n_br_fiscal/models/document_line_abstract.py
+++ b/l10n_br_fiscal/models/document_line_abstract.py
@@ -97,9 +97,6 @@ class DocumentLineAbstract(models.AbstractModel):
         comodel_name="product.product",
         string="Product")
 
-    notes = fields.Text(
-        string="Notes")
-
     # Amount Fields
     amount_estimate_tax = fields.Monetary(
         string="Amount Estimate Total",

--- a/l10n_br_fiscal/models/operation.py
+++ b/l10n_br_fiscal/models/operation.py
@@ -103,7 +103,7 @@ class Operation(models.Model):
 
     comment_ids = fields.Many2many(
         comodel_name="l10n_br_fiscal.comment",
-        relation="l10n_br_fiscal_operation_line_comment_rel",
+        relation="l10n_br_fiscal_operation_comment_rel",
         column1="operation_id",
         column2="comment_id",
         string="Comment")

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -126,8 +126,6 @@ class OperationLine(models.Model):
         column2="comment_id",
         string="Comment")
 
-    additional_data = fields.Text(string="Additional Data")
-
     state = fields.Selection(
         selection=OPERATION_STATE,
         string="State",

--- a/l10n_br_fiscal/models/operation_line.py
+++ b/l10n_br_fiscal/models/operation_line.py
@@ -126,6 +126,8 @@ class OperationLine(models.Model):
         column2="comment_id",
         string="Comment")
 
+    additional_data = fields.Text(string="Additional Data")
+
     state = fields.Selection(
         selection=OPERATION_STATE,
         string="State",

--- a/l10n_br_fiscal/tests/test_fiscal_document_generic.py
+++ b/l10n_br_fiscal/tests/test_fiscal_document_generic.py
@@ -120,6 +120,8 @@ class TestFiscalDocumentGeneric(TransactionCase):
                 "Error to mapping CST 01 - Operação Tributável com Alíquota Básica"
                 " Básica to COFINS 3% de Venda de Contribuinte Dentro do Estado.")
 
+        self.nfe_same_state.action_document_confirm()
+
     def test_nfe_other_state(self):
         """ Test NFe other state. """
 

--- a/l10n_br_fiscal/views/comment_view.xml
+++ b/l10n_br_fiscal/views/comment_view.xml
@@ -51,7 +51,6 @@
                         <group>
                             <field name="date_begin"/>
                             <field name="date_end"/>
-                            <field name="document"/>
                         </group>
                     </group>
                     <group string="Test Message">

--- a/l10n_br_fiscal/views/comment_view.xml
+++ b/l10n_br_fiscal/views/comment_view.xml
@@ -58,9 +58,9 @@
                             <field name="object_id"/>
                         </group>
                         <group>
-                            <button name="action_compute_message" type="object" class="btn btn-primary" string="Test"/>
+                            <button name="action_test_message" type="object" class="btn btn-primary" string="Test"/>
                         </group>
-                        <field name="processed_comment" readonly="1"/>
+                        <field name="test_comment" readonly="1"/>
                     </group>
                 </sheet>
             </form>

--- a/l10n_br_fiscal/views/comment_view.xml
+++ b/l10n_br_fiscal/views/comment_view.xml
@@ -8,7 +8,8 @@
             <search string="Comment">
                 <field name="name"/>
                 <group expand='0' string='Group By...'>
-                    <filter string='Comment Type' name="comment_type" domain="[]" context="{'group_by' : 'comment_type'}"/>
+                    <filter string='Comment Type' name="comment_type" domain="[]"
+                            context="{'group_by' : 'comment_type'}"/>
                 </group>
             </search>
         </field>
@@ -50,7 +51,17 @@
                         <group>
                             <field name="date_begin"/>
                             <field name="date_end"/>
+                            <field name="document"/>
                         </group>
+                    </group>
+                    <group string="Test Message">
+                        <group>
+                            <field name="object_id"/>
+                        </group>
+                        <group>
+                            <button name="action_compute_message" type="object" class="btn btn-primary" string="Test"/>
+                        </group>
+                        <field name="processed_comment" readonly="1"/>
                     </group>
                 </sheet>
             </form>

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -354,11 +354,6 @@
                 </page>
             </notebook>
           </page>
-          <page name="others" string="Others">
-            <group>
-              <field name="notes"/>
-            </group>
-          </page>
           <page name="amounts" string="Amounts">
             <group>
               <group>

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -381,7 +381,7 @@
           <page name="extra_info" string="Extra Info">
             <group>
                 <field name="comment_ids" widget="many2many_tags" domain="[('object','=','l10n_br_fiscal.document.line')]"/>
-                <field name="processed_comments"/>
+                <field name="additional_data"/>
             </group>
           </page>
         </notebook>

--- a/l10n_br_fiscal/views/document_line_view.xml
+++ b/l10n_br_fiscal/views/document_line_view.xml
@@ -378,6 +378,12 @@
               </group>
             </group>
           </page>
+          <page name="extra_info" string="Extra Info">
+            <group>
+                <field name="comment_ids" widget="many2many_tags" domain="[('object','=','l10n_br_fiscal.document.line')]"/>
+                <field name="processed_comments"/>
+            </group>
+          </page>
         </notebook>
       </form>
     </field>

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -245,6 +245,13 @@
                 </group>
               </group>
             </page>
+                        <page name="extra_info" string="Extra Info">
+                            <group>
+                                <field name="comment_ids" widget="many2many_tags"
+                                       domain="[('object','=','l10n_br_fiscal.document')]"/>
+                                <field name="processed_comments"/>
+                            </group>
+                        </page>
           </notebook>
         </sheet>
         <div class="oe_chatter">

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -249,7 +249,7 @@
                             <group>
                                 <field name="comment_ids" widget="many2many_tags"
                                        domain="[('object','=','l10n_br_fiscal.document')]"/>
-                                <field name="processed_comments"/>
+                                <field name="additional_data"/>
                             </group>
                         </page>
           </notebook>

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -50,6 +50,12 @@
                       <page name="tax_definitions" string="Tax Definitions">
                           <field name="tax_definition_ids" nolabel="1" context="{'tree_view_ref': 'l10n_br_fiscal.tax_definition_tree','form_view_ref': 'l10n_br_fiscal.tax_definition_form', 'default_operation_line_id': id}"/>
                       </page>
+                      <page name="extra_info" string="Extra Info">
+                        <group>
+                            <field name="comment_ids" widget="many2many_tags" domain="[('object','=','l10n_br_fiscal.document.line')]"/>
+                            <field name="additional_data"/>
+                        </group>
+                      </page>
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">

--- a/l10n_br_fiscal/views/operation_line_view.xml
+++ b/l10n_br_fiscal/views/operation_line_view.xml
@@ -53,7 +53,6 @@
                       <page name="extra_info" string="Extra Info">
                         <group>
                             <field name="comment_ids" widget="many2many_tags" domain="[('object','=','l10n_br_fiscal.document.line')]"/>
-                            <field name="additional_data"/>
                         </group>
                       </page>
                     </notebook>


### PR DESCRIPTION
Implementados comentários para fiscal.document e fiscal.document.line. 

Os comentários são criados em Fiscal > Configuração > Comentário (é possível testar o comentário na mesma página).

No campo comentário é possível acessar o fiscal document da seguinte maneira:
- "${doc}"
Suas propriedades são acessadas de forma parecida:
- "${doc.amount_total}"

Ao confirmar um documento, os comentários do documento e de suas linhas serão processados e anexados com possíveis comentários manuais adicionados. 

Para adicionar comentários manuais e/ou visualizar os comentários processados:
- Fiscal > Document > Aba Extra Info > Campo Processed comment

No documento e nas linhas (ambos na aba extra info) é possível selecionar quais são os comentários que serão utilizados. Campo comments (many2many tags)