### PR TITLE
Feature/dashboard fiscal

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -78,6 +78,7 @@
         "views/l10n_br_fiscal_action.xml",
         "views/l10n_br_fiscal_menu.xml",
         "views/uom_uom.xml",
+        "views/operation_dashboard_view.xml",
     ],
     "demo": [
         # Some demo data is being loaded via post_init_hook in hook file

--- a/l10n_br_fiscal/models/__init__.py
+++ b/l10n_br_fiscal/models/__init__.py
@@ -60,3 +60,4 @@ from . import res_country_state
 from . import uom_category
 from . import uom_uom
 from . import uom_uom_alternative
+from . import operation_dashboard

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -34,6 +34,18 @@ class Document(models.Model):
                "'|', ('operation_type', '=', operation_type),"
                " ('operation_type', '=', 'all')]")
 
+    document_section = fields.Selection(
+        selection=[
+            ('nfe', 'NF-e'),
+            ('nfse_recibos', 'NFS-e e Recibos'),
+            ('nfce_cfe', 'NFC-e e CF-e'),
+            ('cte', 'CT-e'),
+            ('todos', 'Todos'),
+        ],
+        string='Seção do documento',
+        readonly=True,
+    )
+
     edoc_purpose = fields.Selection(
         selection=[
             ('1', 'Normal'),
@@ -93,6 +105,38 @@ class Document(models.Model):
     def _onchange_operation_id(self):
         if self.operation_id:
             self.operation_name = self.operation_id.name
+
+    @api.multi
+    @api.onchange('document_section')
+    def _onchange_document_section(self):
+        if self.document_section:
+            domain = dict()
+            if self.document_section == 'nfe':
+                domain['document_type_id'] = [('code', '=', '55')]
+                self.document_type_id = \
+                    self.env['l10n_br_fiscal.document.type'].search([
+                        ('code', '=', '55')
+                    ])[0]
+            elif self.document_section == 'nfse_recibos':
+                domain['document_type_id'] = [('code', '=', 'SE')]
+                self.document_type_id = \
+                    self.env['l10n_br_fiscal.document.type'].search([
+                        ('code', '=', 'SE')
+                    ])[0]
+            elif self.document_section == 'nfce_cfe':
+                domain['document_type_id'] = [('code', 'in', ('59', '65'))]
+                self.document_type_id = \
+                    self.env['l10n_br_fiscal.document.type'].search([
+                        ('code', '=', '59')
+                    ])[0]
+            elif self.document_section == 'cte':
+                domain['document_type_id'] = [('code', '=', '57')]
+                self.document_type_id = \
+                    self.env['l10n_br_fiscal.document.type'].search([
+                        ('code', '=', '57')
+                    ])[0]
+
+            return {'domain': domain}
 
     @api.multi
     @api.constrains("number")

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -39,16 +39,34 @@ class Document(models.Model):
             ('1', 'Normal'),
             ('2', 'Complementar'),
             ('3', 'Ajuste'),
-            ('4', 'Devolução de mercadoria')],
+            ('4', 'Devolução de mercadoria'),
+        ],
         string='Finalidade',
-        default='1')
+        default='1',
+    )
 
     ind_final = fields.Selection(
         selection=[
             ('0', 'Não'),
-            ('1', 'Sim')],
+            ('1', 'Sim')
+        ],
         string='Operação com consumidor final',
-        default='1')
+        default='1',
+    )
+
+    ind_pres = fields.Selection(
+        selection=[
+            ('0', 'Não se aplica'),
+            ('1', 'Operação presencial'),
+            ('2', 'Não presencial, internet'),
+            ('3', 'Não presencial, teleatendimento'),
+            ('4', 'NFC-e entrega em domicílio'),
+            ('5', 'Operação presencial, fora do estabelecimento'),
+            ('9', 'Não presencial, outros'),
+        ],
+        string='Indicador de presença do comprador no estabelecimento',
+        default='0',
+    )
 
     line_ids = fields.One2many(
         comodel_name="l10n_br_fiscal.document.line",
@@ -69,6 +87,12 @@ class Document(models.Model):
     state = fields.Selection(
         related="state_edoc",
         string="State")
+
+    @api.multi
+    @api.onchange("operation_id")
+    def _onchange_operation_id(self):
+        if self.operation_id:
+            self.operation_name = self.operation_id.name
 
     @api.multi
     @api.constrains("number")

--- a/l10n_br_fiscal/models/operation_dashboard.py
+++ b/l10n_br_fiscal/models/operation_dashboard.py
@@ -1,0 +1,147 @@
+# Copyright (C) 2020  KMEE - www.kmee.com.br
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import json
+from odoo import _, api, fields, models
+
+
+class Operation(models.Model):
+    _inherit = "l10n_br_fiscal.operation"
+
+    @api.one
+    def _kanban_dashboard(self):
+        self.kanban_dashboard = json.dumps(
+            self.get_operation_dashboard_datas())
+
+    kanban_dashboard = fields.Text(compute='_kanban_dashboard')
+    color = fields.Integer("Color Index", default=0)
+
+    @api.multi
+    def get_operation_dashboard_datas(self):
+        title = ''
+        if self.fiscal_type in ('sale', 'purchase'):
+            title = _('Bills to pay') if self.fiscal_type == 'purchase' \
+                else _('Invoices owed to you')
+
+        (query, query_args) = self._get_confirmed_documents_query()
+        self.env.cr.execute(query, query_args)
+        query_results_confirmed = self.env.cr.dictfetchall()
+        number_confirm = len(query_results_confirmed)
+
+        (query, query_args) = self._get_authorized_documents_query()
+        self.env.cr.execute(query, query_args)
+        query_results_authorized = self.env.cr.dictfetchall()
+        number_authorized = len(query_results_authorized)
+
+        (query, query_args) = self._get_cancelled_documents_query()
+        self.env.cr.execute(query, query_args)
+        query_results_cancelled = self.env.cr.dictfetchall()
+        number_cancelled = len(query_results_cancelled)
+
+        return {
+            'number_confirm': number_confirm,
+            'number_authorized': number_authorized,
+            'number_cancelled': number_cancelled,
+            'title': title
+        }
+
+    def _get_confirmed_documents_query(self):
+        """
+        Returns a tuple containing as its first element the SQL query used to
+        gather the bills in draft state data, and the arguments
+        dictionary to use to run it as its second.
+        """
+        # there is no account_move_lines for draft invoices, so no relevant
+        # residual_signed value
+        return ("""SELECT doc.company_id
+                  FROM l10n_br_fiscal_document doc
+                  WHERE operation_id = %(operation_id)s
+                  AND state_edoc = 'a_enviar';""", {'operation_id': self.id})
+
+    def _get_authorized_documents_query(self):
+        """
+        Returns a tuple containing as its first element the SQL query used to
+        gather the bills in draft state data, and the arguments
+        dictionary to use to run it as its second.
+        """
+        # there is no account_move_lines for draft invoices, so no relevant
+        # residual_signed value
+        return ("""SELECT doc.company_id
+                  FROM l10n_br_fiscal_document doc
+                  WHERE operation_id = %(operation_id)s
+                  AND state_edoc = 'autorizada';""",
+                {'operation_id': self.id})
+
+    def _get_cancelled_documents_query(self):
+        """
+        Returns a tuple containing as its first element the SQL query used to
+        gather the bills in draft state data, and the arguments
+        dictionary to use to run it as its second.
+        """
+        # there is no account_move_lines for draft invoices, so no relevant
+        # residual_signed value
+        return ("""SELECT doc.company_id
+                  FROM l10n_br_fiscal_document doc
+                  WHERE operation_id = %(operation_id)s
+                  AND state_edoc = 'cancelada';""",
+                {'operation_id': self.id})
+
+    @api.multi
+    def action_create_new(self):
+        ctx = self._context.copy()
+        model = 'l10n_br_fiscal.document'
+        if self.fiscal_type == 'sale':
+            ctx.update({'default_operation_type': 'out',
+                        'default_operation_id': self.id})
+        elif self.fiscal_type == 'purchase':
+            ctx.update({'default_operation_type': 'in',
+                        'default_operation_id': self.id})
+        return {
+            'name': _('Create invoice/bill'),
+            'type': 'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': model,
+            'view_id': self.env.ref('l10n_br_fiscal.document_form').id,
+            'context': ctx,
+        }
+
+    @api.multi
+    def open_action(self):
+        """return action based on type for related journals"""
+
+        _fiscal_type_map = {
+            'purchase': 'in',
+            'purchase_refund': 'in',
+            'return_in': 'in',
+            'sale': 'out',
+            'sale_refund': 'out',
+            'return_out': 'out',
+            'other': 'out',
+        }
+        operation_type = _fiscal_type_map[self.fiscal_type]
+
+        action_name = self._context.get('action_name', False)
+
+        if not action_name:
+            action_name = 'document_out_action' if operation_type == 'out' \
+                else 'document_in_action'
+
+        ctx = self._context.copy()
+        ctx.pop('group_by', None)
+        ctx.update({
+            'default_operation_type': operation_type,
+        })
+
+        [action] = self.env.ref('l10n_br_fiscal.%s' % action_name).read()
+        action['context'] = ctx
+        action['domain'] = self._context.get('use_domain', [])
+        action['domain'] += [
+            ('operation_id.fiscal_type', '=', self.fiscal_type),
+            ('operation_id', '=', self.id)
+        ]
+        if ctx.get('search_default_confirm'):
+            action['domain'] += [('state_edoc', '=', 'a_enviar')]
+        elif ctx.get('search_default_authorized'):
+            action['domain'] += [('state_edoc', '=', 'autorizada')]
+        return action

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -43,6 +43,7 @@
         <field name="currency_id" invisible="1"/>
         <field name="document_electronic" invisible="1"/>
         <field name="operation_type" invisible="1"/>
+        <field name="document_section" invisible="1"/>
         <header>
             <button name="action_document_confirm" type="object" string="Confirmar"   groups="l10n_br_fiscal.group_user"    states="em_digitacao"     class="btn-primary"/>
             <button name="action_document_send"    type="object" string="Enviar"      groups="l10n_br_fiscal.group_user"    states="a_enviar,rejeitada"         class="btn-primary"/>

--- a/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_action.xml
@@ -510,6 +510,66 @@
     </record>
 
     # Fiscal Document In
+    <record id="document_nfe_in_action" model="ir.actions.act_window">
+        <field name="name">NF-e Receivement</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.document</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="search_view_id" ref="document_search"/>
+        <field name="view_id" ref="document_tree"/>
+        <field name="domain">[('operation_type', '=', 'in'), ('document_section', '=', 'nfe')]</field>
+        <field name="context">{'default_operation_type': 'in', 'default_document_section': 'nfe'}</field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new Document
+          </p><p>
+            Odoo helps you easily track all activities
+            related to a fiscal operation.
+          </p>
+        </field>
+    </record>
+
+    <record id="document_nfse_recibos_in_action" model="ir.actions.act_window">
+        <field name="name">NFS-e and Receipts Receivement</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.document</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="search_view_id" ref="document_search"/>
+        <field name="view_id" ref="document_tree"/>
+        <field name="domain">[('operation_type', '=', 'in'), ('document_section', '=', 'nfse_recibos')]</field>
+        <field name="context">{'default_operation_type': 'in', 'default_document_section': 'nfse_recibos'}</field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new Document
+          </p><p>
+            Odoo helps you easily track all activities
+            related to a fiscal operation.
+          </p>
+        </field>
+    </record>
+
+    <record id="document_cte_in_action" model="ir.actions.act_window">
+        <field name="name">CT-e Receivement</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.document</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="search_view_id" ref="document_search"/>
+        <field name="view_id" ref="document_tree"/>
+        <field name="domain">[('operation_type', '=', 'in'), ('document_section', '=', 'cte')]</field>
+        <field name="context">{'default_operation_type': 'in', 'default_document_section': 'cte'}</field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new Document
+          </p><p>
+            Odoo helps you easily track all activities
+            related to a fiscal operation.
+          </p>
+        </field>
+    </record>
+
     <record id="document_in_action" model="ir.actions.act_window">
         <field name="name">Receivement</field>
         <field name="type">ir.actions.act_window</field>
@@ -518,7 +578,7 @@
         <field name="view_mode">kanban,tree,form</field>
         <field name="search_view_id" ref="document_search"/>
         <field name="view_id" ref="document_tree"/>
-        <field name="domain">['|', ('operation_type', '=', 'in'), ('operation_type', '=', 'all')]</field>
+        <field name="domain">[('operation_type', '=', 'in')]</field>
         <field name="context">{'default_operation_type': 'in'}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
@@ -531,6 +591,86 @@
     </record>
 
     # Fiscal Document Out
+    <record id="document_nfe_out_action" model="ir.actions.act_window">
+        <field name="name">NF-e Emission</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.document</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="search_view_id" ref="document_search"/>
+        <field name="view_id" ref="document_tree"/>
+        <field name="domain">[('operation_type', '=', 'out'), ('document_section', '=', 'nfe')]</field>
+        <field name="context">{'default_operation_type': 'out', 'default_document_section': 'nfe'}</field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new Document
+          </p><p>
+            Odoo helps you easily track all activities
+            related to a fiscal operation.
+          </p>
+        </field>
+    </record>
+
+    <record id="document_nfse_recibos_out_action" model="ir.actions.act_window">
+        <field name="name">NFS-e and Receipts Emission</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.document</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="search_view_id" ref="document_search"/>
+        <field name="view_id" ref="document_tree"/>
+        <field name="domain">[('operation_type', '=', 'out'), ('document_section', '=', 'nfse_recibos')]</field>
+        <field name="context">{'default_operation_type': 'out', 'default_document_section': 'nfse_recibos'}</field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new Document
+          </p><p>
+            Odoo helps you easily track all activities
+            related to a fiscal operation.
+          </p>
+        </field>
+    </record>
+
+    <record id="document_nfce_cfe_out_action" model="ir.actions.act_window">
+        <field name="name">NFC-e and CF-e Emission</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.document</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="search_view_id" ref="document_search"/>
+        <field name="view_id" ref="document_tree"/>
+        <field name="domain">[('operation_type', '=', 'out'), ('document_section', '=', 'nfce_cfe')]</field>
+        <field name="context">{'default_operation_type': 'out', 'default_document_section': 'nfce_cfe'}</field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new Document
+          </p><p>
+            Odoo helps you easily track all activities
+            related to a fiscal operation.
+          </p>
+        </field>
+    </record>
+
+    <record id="document_cte_out_action" model="ir.actions.act_window">
+        <field name="name">CT-e Emission</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_br_fiscal.document</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="search_view_id" ref="document_search"/>
+        <field name="view_id" ref="document_tree"/>
+        <field name="domain">[('operation_type', '=', 'out'), ('document_section', '=', 'cte')]</field>
+        <field name="context">{'default_operation_type': 'out', 'default_document_section': 'cte'}</field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new Document
+          </p><p>
+            Odoo helps you easily track all activities
+            related to a fiscal operation.
+          </p>
+        </field>
+    </record>
+
     <record id="document_out_action" model="ir.actions.act_window">
         <field name="name">Emission</field>
         <field name="type">ir.actions.act_window</field>
@@ -539,14 +679,14 @@
         <field name="view_mode">kanban,tree,form</field>
         <field name="search_view_id" ref="document_search"/>
         <field name="view_id" ref="document_tree"/>
-        <field name="domain">['|', ('operation_type', '=', 'out'), ('operation_type', '=', 'all')]</field>
+        <field name="domain">[('operation_type', '=', 'out')]</field>
         <field name="context">{'default_operation_type': 'out'}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             Create a new Document
           </p><p>
-            Odoo helps you to easily track all activities
-            related to a fiscal document.
+            Odoo helps you easily track all activities
+            related to a fiscal operation.
           </p>
         </field>
     </record>

--- a/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
@@ -11,10 +11,28 @@
 <!--    <menuitem id="documents_menu" name="Documents" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="10"/>-->
 
     # Fiscal Documents In
-    <menuitem id="document_in_menu" action="document_in_action" name="Receivement" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="10"/>
+    <menuitem id="document_in_menu" name="Receivement" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="10"/>
+
+    <menuitem id="document_nfe_in_menu" action="document_nfe_in_action" name="NF-e" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="document_in_menu" sequence="10"/>
+
+    <menuitem id="document_nfse_recibos_in_menu" action="document_nfse_recibos_in_action" name="NFS-e e Recibos" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="document_in_menu" sequence="15"/>
+
+    <menuitem id="document_cte_in_menu" action="document_cte_in_action" name="CT-e" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="document_in_menu" sequence="20"/>
+
+    <menuitem id="document_all_in_menu" action="document_in_action" name="Todos" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="document_in_menu" sequence="25"/>
 
     # Fiscal Documents Out
-    <menuitem id="document_out_menu" action="document_out_action" name="Emission" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="11"/>
+    <menuitem id="document_out_menu" name="Emission" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="11"/>
+
+    <menuitem id="document_nfe_out_menu" action="document_nfe_out_action" name="NF-e" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="document_out_menu" sequence="10"/>
+
+    <menuitem id="document_nfse_recibos_out_menu" action="document_nfse_recibos_out_action" name="NFS-e e Recibos" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="document_out_menu" sequence="15"/>
+
+    <menuitem id="document_nfce_cfe_out_menu" action="document_nfce_cfe_out_action" name="NFC-e e CF-e" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="document_out_menu" sequence="20"/>
+
+    <menuitem id="document_cte_out_menu" action="document_cte_out_action" name="CT-e" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="document_out_menu" sequence="25"/>
+
+    <menuitem id="document_all_out_menu" action="document_out_action" name="Todos" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="document_out_menu" sequence="30"/>
 
     <!-- Partners -->
     <menuitem id="partners_menu" name="Partners" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="20"/>

--- a/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
+++ b/l10n_br_fiscal/views/l10n_br_fiscal_menu.xml
@@ -7,14 +7,14 @@
     <!-- Fiscal Overview -->
     <menuitem id="overview_menu" name="Overview" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="0"/>
 
-    <!-- Fiscal Documents -->
-    <menuitem id="documents_menu" name="Documents" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="10"/>
+<!--    # Fiscal Documents-->
+<!--    <menuitem id="documents_menu" name="Documents" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="10"/>-->
 
-    <!-- Fiscal Documents In -->
-    <menuitem id="document_in_menu" action="document_in_action" name="Receivement" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="documents_menu" sequence="10"/>
+    # Fiscal Documents In
+    <menuitem id="document_in_menu" action="document_in_action" name="Receivement" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="10"/>
 
-    <!-- Fiscal Documents Out -->
-    <menuitem id="document_out_menu" action="document_out_action" name="Emission" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="documents_menu" sequence="11"/>
+    # Fiscal Documents Out
+    <menuitem id="document_out_menu" action="document_out_action" name="Emission" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="11"/>
 
     <!-- Partners -->
     <menuitem id="partners_menu" name="Partners" groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager" parent="fiscal_menu" sequence="20"/>

--- a/l10n_br_fiscal/views/operation_dashboard_view.xml
+++ b/l10n_br_fiscal/views/operation_dashboard_view.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="operation_dashboard_kanban_view" model="ir.ui.view">
+        <field name="name">l10n_br_fiscal.operation.dashboard.kanban</field>
+        <field name="model">l10n_br_fiscal.operation</field>
+        <field name="arch" type="xml">
+            <kanban class="oe_background_grey o_kanban_dashboard o_account_kanban">
+                <field name="fiscal_type"/>
+                <field name="kanban_dashboard"/>
+                <field name="color"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div t-attf-class="#{kanban_color(record.color.raw_value)}">
+                            <t t-value="JSON.parse(record.kanban_dashboard.raw_value)" t-set="dashboard"/>
+                            <t t-value="record.fiscal_type.raw_value" t-set="fiscal_type"/>
+                            <t t-call="OperationTop"/>
+                            <div class="container o_kanban_card_content">
+                                <div class="row">
+<!--                                    <t t-if="(journal_type == 'bank' || journal_type == 'cash')" t-call="JournalBodyBankCash"/>-->
+                                    <t t-call="OperationBody"/>
+                                </div>
+<!--                                <t t-if="journal_type == 'bank' || journal_type == 'cash' || journal_type == 'sale' || journal_type == 'purchase'" t-call="JournalBodyGraph"/>-->
+                            </div>
+<!--                            <div class="container o_kanban_card_manage_pane dropdown-menu" role="menu">-->
+<!--                                <t t-call="JournalManage"/>-->
+<!--                            </div>-->
+                        </div>
+                    </t>
+
+                    <t t-name="OperationTop">
+                        <div t-attf-class="o_kanban_card_header">
+                            <div class="o_kanban_card_header_title">
+                                <div class="o_primary">
+                                    <a type="object" name="open_action"><field name="name"/></a>
+                                </div>
+                                <div class="o_secondary" t-att-title="dashboard.title">
+                                    <field name="fiscal_type"/>
+                                </div>
+                            </div>
+                            <div class="o_kanban_manage_button_section">
+                                <a class="o_kanban_manage_toggle_button" href="#"><i class="fa fa-ellipsis-v" aria-label="Selection" role="img" title="Selection"/></a>
+                            </div>
+                        </div>
+                    </t>
+
+                    <t t-name="OperationBody" id="l10n_br_fiscal.OperationBodySalePurchase">
+                        <div class="col-3 o_kanban_primary_left">
+                            <t t-if="fiscal_type == 'sale'">
+                                <button type="object" name="action_create_new" class="btn btn-primary o_invoice_new">
+                                    <span>Nova Fatura</span>
+                                </button>
+                            </t>
+                            <t t-if="fiscal_type == 'purchase'">
+                                <button type="object" name="action_create_new" class="btn btn-primary">
+                                    <span>Nova Compra</span>
+                                </button>
+                            </t>
+                        </div>
+                        <div class="col-10 o_kanban_primary_right">
+                            <div class="row">
+                                <div class="col-10">
+                                    <a type="object" name="open_action" context="{'search_default_confirm': '1'}">
+                                        <span t-if="fiscal_type == 'sale'" title="Faturas confirmadas"><t t-esc="dashboard.number_confirm"/> Faturas confirmadas</span>
+                                        <span t-if="fiscal_type == 'purchase'" title="Compras confirmadas"><t t-esc="dashboard.number_confirm"/> Compras confirmadas</span>
+                                        <span t-if="fiscal_type == 'other' || fiscal_type == 'purchase_refund' || fiscal_type == 'return_in' || fiscal_type == 'sale_refund' || fiscal_type == 'return_out'" title="Documentos confirmados"><t t-esc="dashboard.number_confirm"/> Documentos confirmados</span>
+                                    </a>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-10">
+                                    <a type="object" t-if="fiscal_type == 'sale'" name="open_action"
+                                    context="{'search_default_authorized':1}" id="fiscal_dashboard_sale_pay_link">
+                                        <t t-esc="dashboard.number_authorized"/> Faturas autorizadas
+                                    </a>
+
+                                    <a type="object" t-if="fiscal_type == 'purchase'" name="open_action"
+                                    context="{'search_default_authorized':1}" id="fiscal_dashboard_purchase_pay_link">
+                                        <t t-esc="dashboard.number_authorized"/> Compras autorizadas
+                                    </a>
+
+                                    <a type="object" t-if="fiscal_type == 'other' || fiscal_type == 'purchase_refund' || fiscal_type == 'return_in' || fiscal_type == 'sale_refund' || fiscal_type == 'return_out'" name="open_action"
+                                    context="{'search_default_authorized':1}" id="fiscal_dashboard_purchase_pay_link">
+                                        <t t-esc="dashboard.number_authorized"/> Documentos autorizados
+                                    </a>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-10">
+                                    <a type="object" name="open_action" context="{'search_default_cancelled': '1'}">
+                                        <span t-if="fiscal_type == 'sale'" title="Faturas canceladas"><t t-esc="dashboard.number_confirm"/> Faturas canceladas</span>
+                                        <span t-if="fiscal_type == 'purchase'" title="Compras canceladas"><t t-esc="dashboard.number_confirm"/> Compras canceladas</span>
+                                        <span t-if="fiscal_type == 'other' || fiscal_type == 'purchase_refund' || fiscal_type == 'return_in' || fiscal_type == 'sale_refund' || fiscal_type == 'return_out'" title="Documentos cancelados"><t t-esc="dashboard.number_confirm"/> Documentos cancelados</span>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="open_operation_dashboard_kanban" model="ir.actions.act_window">
+        <field name="name">Fiscal Overview</field>
+        <field name="res_model">l10n_br_fiscal.operation</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">kanban,form</field>
+        <field name="view_id" ref="operation_dashboard_kanban_view"/>
+        <field name="usage">menu</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_neutral_face">
+                This is the fiscal dashboard
+            </p>
+        </field>
+    </record>
+
+    <menuitem id="menu_board_operation_1" name="Overview" action="open_operation_dashboard_kanban" parent="fiscal_menu" sequence="1"/>
+</odoo>

--- a/l10n_br_fiscal/views/operation_dashboard_view.xml
+++ b/l10n_br_fiscal/views/operation_dashboard_view.xml
@@ -4,93 +4,61 @@
         <field name="name">l10n_br_fiscal.operation.dashboard.kanban</field>
         <field name="model">l10n_br_fiscal.operation</field>
         <field name="arch" type="xml">
-            <kanban class="oe_background_grey o_kanban_dashboard o_account_kanban">
+            <kanban class="oe_background_grey o_kanban_dashboard o_emphasize_colors o_stock_kanban">
                 <field name="fiscal_type"/>
                 <field name="kanban_dashboard"/>
                 <field name="color"/>
                 <templates>
                     <t t-name="kanban-box">
-                        <div t-attf-class="#{kanban_color(record.color.raw_value)}">
+                        <div t-attf-class="#{kanban_color(record.color.raw_value)}" name="operation_dashboard">
                             <t t-value="JSON.parse(record.kanban_dashboard.raw_value)" t-set="dashboard"/>
                             <t t-value="record.fiscal_type.raw_value" t-set="fiscal_type"/>
-                            <t t-call="OperationTop"/>
-                            <div class="container o_kanban_card_content">
-                                <div class="row">
-<!--                                    <t t-if="(journal_type == 'bank' || journal_type == 'cash')" t-call="JournalBodyBankCash"/>-->
-                                    <t t-call="OperationBody"/>
+                            <div>
+                                <div t-attf-class="o_kanban_card_header">
+                                    <div class="o_kanban_card_header_title">
+                                        <div class="o_primary">
+                                            <a type="object" name="open_action"><field name="name"/></a>
+                                        </div>
+                                        <div class="o_secondary" t-att-title="dashboard.title">
+                                            <field name="fiscal_type"/>
+                                        </div>
+                                    </div>
+                                    <div class="o_kanban_manage_button_section">
+                                        <a class="o_kanban_manage_toggle_button" href="#"><i class="fa fa-ellipsis-v" role="img" aria-label="Manage" title="Manage"/></a>
+                                    </div>
                                 </div>
-<!--                                <t t-if="journal_type == 'bank' || journal_type == 'cash' || journal_type == 'sale' || journal_type == 'purchase'" t-call="JournalBodyGraph"/>-->
-                            </div>
-<!--                            <div class="container o_kanban_card_manage_pane dropdown-menu" role="menu">-->
-<!--                                <t t-call="JournalManage"/>-->
-<!--                            </div>-->
-                        </div>
-                    </t>
-
-                    <t t-name="OperationTop">
-                        <div t-attf-class="o_kanban_card_header">
-                            <div class="o_kanban_card_header_title">
-                                <div class="o_primary">
-                                    <a type="object" name="open_action"><field name="name"/></a>
-                                </div>
-                                <div class="o_secondary" t-att-title="dashboard.title">
-                                    <field name="fiscal_type"/>
-                                </div>
-                            </div>
-                            <div class="o_kanban_manage_button_section">
-                                <a class="o_kanban_manage_toggle_button" href="#"><i class="fa fa-ellipsis-v" aria-label="Selection" role="img" title="Selection"/></a>
-                            </div>
-                        </div>
-                    </t>
-
-                    <t t-name="OperationBody" id="l10n_br_fiscal.OperationBodySalePurchase">
-                        <div class="col-3 o_kanban_primary_left">
-                            <t t-if="fiscal_type == 'sale'">
-                                <button type="object" name="action_create_new" class="btn btn-primary o_invoice_new">
-                                    <span>Nova Fatura</span>
-                                </button>
-                            </t>
-                            <t t-if="fiscal_type == 'purchase'">
-                                <button type="object" name="action_create_new" class="btn btn-primary">
-                                    <span>Nova Compra</span>
-                                </button>
-                            </t>
-                        </div>
-                        <div class="col-10 o_kanban_primary_right">
-                            <div class="row">
-                                <div class="col-10">
-                                    <a type="object" name="open_action" context="{'search_default_confirm': '1'}">
-                                        <span t-if="fiscal_type == 'sale'" title="Faturas confirmadas"><t t-esc="dashboard.number_confirm"/> Faturas confirmadas</span>
-                                        <span t-if="fiscal_type == 'purchase'" title="Compras confirmadas"><t t-esc="dashboard.number_confirm"/> Compras confirmadas</span>
-                                        <span t-if="fiscal_type == 'other' || fiscal_type == 'purchase_refund' || fiscal_type == 'return_in' || fiscal_type == 'sale_refund' || fiscal_type == 'return_out'" title="Documentos confirmados"><t t-esc="dashboard.number_confirm"/> Documentos confirmados</span>
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-10">
-                                    <a type="object" t-if="fiscal_type == 'sale'" name="open_action"
-                                    context="{'search_default_authorized':1}" id="fiscal_dashboard_sale_pay_link">
-                                        <t t-esc="dashboard.number_authorized"/> Faturas autorizadas
-                                    </a>
-
-                                    <a type="object" t-if="fiscal_type == 'purchase'" name="open_action"
-                                    context="{'search_default_authorized':1}" id="fiscal_dashboard_purchase_pay_link">
-                                        <t t-esc="dashboard.number_authorized"/> Compras autorizadas
-                                    </a>
-
-                                    <a type="object" t-if="fiscal_type == 'other' || fiscal_type == 'purchase_refund' || fiscal_type == 'return_in' || fiscal_type == 'sale_refund' || fiscal_type == 'return_out'" name="open_action"
-                                    context="{'search_default_authorized':1}" id="fiscal_dashboard_purchase_pay_link">
-                                        <t t-esc="dashboard.number_authorized"/> Documentos autorizados
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-10">
-                                    <a type="object" name="open_action" context="{'search_default_cancelled': '1'}">
-                                        <span t-if="fiscal_type == 'sale'" title="Faturas canceladas"><t t-esc="dashboard.number_confirm"/> Faturas canceladas</span>
-                                        <span t-if="fiscal_type == 'purchase'" title="Compras canceladas"><t t-esc="dashboard.number_confirm"/> Compras canceladas</span>
-                                        <span t-if="fiscal_type == 'other' || fiscal_type == 'purchase_refund' || fiscal_type == 'return_in' || fiscal_type == 'sale_refund' || fiscal_type == 'return_out'" title="Documentos cancelados"><t t-esc="dashboard.number_confirm"/> Documentos cancelados</span>
-                                    </a>
+                                <div class="container o_kanban_card_content">
+                                    <div class="row">
+                                        <div class="col-6 o_kanban_primary_left">
+                                            <button type="object" name="action_create_new" class="btn btn-primary o_invoice_new">
+                                                <span>Novo Documento</span>
+                                            </button>
+                                        </div>
+                                        <div class="col-6 o_kanban_primary_right">
+                                            <div class="row">
+                                                <div class="col-10">
+                                                    <a type="object" name="open_action" context="{'search_default_confirm': '1'}">
+                                                        <span title="Confirmados"><t t-esc="dashboard.number_confirm"/> Confirmados</span>
+                                                    </a>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-10">
+                                                    <a type="object" name="open_action"
+                                                    context="{'search_default_authorized':1}" id="fiscal_dashboard_sale_pay_link">
+                                                        <t t-esc="dashboard.number_authorized"/> Autorizados
+                                                    </a>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-10">
+                                                    <a type="object" name="open_action" context="{'search_default_cancelled': '1'}">
+                                                        <span title="Faturas canceladas"><t t-esc="dashboard.number_confirm"/> Cancelados</span>
+                                                    </a>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -22,7 +22,7 @@
         # Action
         "views/nfe_action.xml",
         # Menu
-        "views/nfe_menu.xml",
+        # "views/nfe_menu.xml",
     ],
     "installable": False,
     "auto_install": False,

--- a/l10n_br_nfe/views/nfe_document_view.xml
+++ b/l10n_br_nfe/views/nfe_document_view.xml
@@ -118,7 +118,7 @@
                 <tree>
                   <field name="product_id"/>
                   <field name="uom_id"/>
-                  <field name="price"/>
+                  <field name="fiscal_price"/>
                   <field name="quantity"/>
                   <field name="amount_total"/>
                 </tree>


### PR DESCRIPTION
Nesse PR será feita a refatoração dos menus fiscais, substituição do menu Documents pelos menus:
 - Emissão:
   -> NF-e
   -> NFS-e e Recibos
   -> NFC-e e CF-e
   -> CT-e
   -> Todos
 - Recebimento:
   -> NF-e
   -> NFS-e e Recibos
   -> CT-e
   -> Todos

Além disso, será desenvolvido do dashboard do fiscal:
 - Cada card equivale a um tipo fiscal de operação
 - Um botão para criação de novo documento
 - Terá um resumo do total de notas em Rascunho, Aguardando envio e Autorizada
 - Ao clicar no card será redirecionado para o menu Todos do respectivo tipo (Emissão ou Recebimento) com um domínio filtrando apenas para o tipo fiscal selecionado

![Captura de tela de 2020-03-18 16-19-34](https://user-images.githubusercontent.com/9100543/76999555-93ad1b00-6935-11ea-8ec7-ea679d17f5ca.png)

