### PR TITLE
Insert fiscal_operation_line_id on line.section

### DIFF
--- a/l10n_br_sale/views/sale_view.xml
+++ b/l10n_br_sale/views/sale_view.xml
@@ -132,6 +132,9 @@
                     </div>
                 </group>
             </xpath>
+            <xpath expr="//field[@name='order_line']/form/field[@name='name']" position="before">
+                <field name="fiscal_operation_line_id"/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Como comentado no pr por mim(https://github.com/OCA/l10n-brazil/pull/755#issuecomment-683296345) e pelo Gabriel (https://github.com/OCA/l10n-brazil/pull/755#issuecomment-687288920), este campo ñ estava disponível na view...