### PR TITLE
[12.0-l10n_br_nfe-ak-filtered][FIX] icms orig and cst value

### DIFF
--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -278,8 +278,6 @@ class NFeLine(spec_models.StackedModel):
             'UFST': self.partner_id.state_id.code,
 
             # ICMS ST Dest
-            'orig': '',
-            'CST': '',
             'vBCSTRet': '',
             'pST': '',
             'vICMSSubstituto': '',


### PR DESCRIPTION
cc @rvalyi @renatonlima 

As tags já são preenchidas aqui:
https://github.com/akretion/l10n-brazil/blob/ad0f0393c554157a7ed18d36ec0511db7b4a131d/l10n_br_nfe/models/document_line.py#L262

![image](https://user-images.githubusercontent.com/3595132/106374718-635f4700-6364-11eb-975e-baf049901050.png)


