### PR TITLE
[12.0-l10n_br_nfe-ak-filtered] fix warnings

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -95,7 +95,7 @@ class NFe(spec_models.StackedModel):
     fiscal_document_event_ids = fields.One2many(
         comodel_name='l10n_br_fiscal.document.event',
         inverse_name='fiscal_document_id',
-        string='Events',
+        string='Fiscal Events',
         copy=False,
     )
 
@@ -174,6 +174,7 @@ class NFe(spec_models.StackedModel):
 
     nfe40_indIEDest = fields.Selection(
         related='partner_ind_ie_dest',
+        string='Contribuinte do ICMS (NFe)'
     )
 
     nfe40_tpNF = fields.Selection(
@@ -203,6 +204,8 @@ class NFe(spec_models.StackedModel):
 
     nfe40_CRT = fields.Selection(
         related='company_tax_framework',
+        string='Código de Regime Tributário (NFe)',
+
     )
 
     nfe40_vFrete = fields.Monetary(

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -61,10 +61,12 @@ class NFeLine(spec_models.StackedModel):
 
     nfe40_vUnCom = fields.Float(
         related='price_unit',
+        string='Valor unitário de comercialização',
     )
 
     nfe40_vUnTrib = fields.Float(
         related='fiscal_price',
+        string='Valor unitário de tributação',
     )
 
     nfe40_choice9 = fields.Selection([
@@ -106,11 +108,13 @@ class NFeLine(spec_models.StackedModel):
     nfe40_choice13 = fields.Selection(
         compute='_compute_nfe40_choice13',
         store=True,
+        string='Tipo de Tributação do PIS',
     )
 
     nfe40_choice16 = fields.Selection(
         compute='_compute_nfe40_choice16',
         store=True,
+        string='Tipo de Tributação do COFINS'
     )
 
     nfe40_orig = fields.Selection(
@@ -163,6 +167,16 @@ class NFeLine(spec_models.StackedModel):
 
     nfe40_vTotTrib = fields.Monetary(
         related='amount_estimate_tax',
+    )
+
+    # Todo: Calcular
+    nfe40_vFCPUFDest = fields.Monetary(
+        string='Valor total do ICMS relativo ao Fundo de Combate à Pobreza',
+    )
+
+    # Todo: Calcular
+    nfe40_vFCPSTRet = fields.Monetary(
+        string='Valor do ICMS relativo ao Fundo de Combate à Pobreza Retido por ST',
     )
 
     @api.depends('icms_cst_id')

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -169,6 +169,24 @@ class NFeLine(spec_models.StackedModel):
         related='amount_estimate_tax',
     )
 
+    nfe40_PISAliq = fields.Many2one(
+        "nfe.40.pisaliq",
+        string="Código de Situação Tributária do PIS (Alíquota)",
+        help="Código de Situação Tributária do PIS."
+        "\n01 – Operação Tributável - Base de Cálculo = Valor da Operação"
+        "\nAlíquota Normal (Cumulativo/Não Cumulativo);"
+        "\n02 - Operação Tributável - Base de Calculo = Valor da Operação"
+        "\n(Alíquota Diferenciada);")
+
+    nfe40_COFINSAliq = fields.Many2one(
+        "nfe.40.cofinsaliq",
+        string="Código de Situação Tributária do COFINS (Alíquota)",
+        help="Código de Situação Tributária do COFINS."
+             "\n01 – Operação Tributável - Base de Cálculo = Valor da Operação"
+             "\nAlíquota Normal (Cumulativo/Não Cumulativo);"
+             "\n02 - Operação Tributável - Base de Calculo = Valor da Operação"
+             "\n(Alíquota Diferenciada);")
+
     # Todo: Calcular
     nfe40_vFCPUFDest = fields.Monetary(
         string='Valor total do ICMS relativo ao Fundo de Combate à Pobreza',

--- a/l10n_br_nfe/models/document_related.py
+++ b/l10n_br_nfe/models/document_related.py
@@ -37,6 +37,11 @@ class NFeRelated(spec_models.StackedModel):
         inverse='_inverse_nfe40_refNFe',
     )
 
+    nfe40_choice5 = fields.Selection([
+        ('nfe40_CNPJ', 'CNPJ'),
+        ('nfe40_CPF', 'CPF')],
+        "CNPJ/CPF do Produtor")
+
     # TODO
     # nfe40_refNF = fields.Many2one(
     #     compute='_compute_nfe_data',

--- a/l10n_br_nfe/models/res_partner.py
+++ b/l10n_br_nfe/models/res_partner.py
@@ -58,6 +58,11 @@ class ResPartner(spec_models.SpecModel):
     nfe40_ISUF = fields.Char(related='suframa')
     nfe40_email = fields.Char(related='email')
 
+    nfe40_choice2 = fields.Selection([
+        ('nfe40_CNPJ', 'CNPJ'),
+        ('nfe40_CPF', 'CPF')],
+        "CNPJ/CPF do Parceiro")
+
     @api.multi
     def _compute_nfe40_enderDest(self):
         for rec in self:

--- a/l10n_br_nfe/views/res_config_settings_view.xml
+++ b/l10n_br_nfe/views/res_config_settings_view.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="l10n_br_fiscal.l10n_br_fiscal_res_config_settings_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@id='l10n_br_fiscal']" position="inside">
-                <div id="nfe" groups="nfe.group_manager">
+                <div id="nfe" groups="l10n_br_nfe.group_manager">
                 <h2>NF-e</h2>
                 <div class="row mt16 o_settings_container">
                     <div class="col-12 col-lg-6 o_setting_box">


### PR DESCRIPTION
@rvalyi ainda sobraram alguns mas se quiser criticar o que foi feito até agora eu agradeço.

Fiquei com dúvida de como proceder com este caso:
Two fields (nfe40_PISAliq, nfe40_CST) of l10n_br_fiscal.document.line() have the same label: Código de Situação Tributária do PIS. 

O campo nfe40_PISAliq tem relação com a tabela nfe.40.pisaliq e o campo nfe40_CST existe em outros impostos tbm.