### PR TITLE
[12.0][IMP] Dados de demonstração e testes para NFe

### DIFF
--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -175,4 +175,68 @@
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]"/>
     </function>
+
+    <!-- NFe Test - Pessoa Física - ICMS 18% resale for NCM 94052000 -->
+    <record id="demo_nfe_natural_icms_18_resale" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
+        <field name="document_serie_id" ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"/>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido"/>
+        <field name="company_number">1</field>
+        <field name="document_serie">1</field>
+        <field name="document_section">nfe</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente11_sp"/>
+        <field name="user_id" ref="base.user_demo"/>
+        <field name="partner_legal_name">Cliente 11 SP - PF Não Contribuinte</field>
+        <field name="partner_name">Cliente 11 SP - PF</field>
+        <field name="partner_cnpj_cpf">765.865.078-12</field>
+        <field name="partner_inscr_est">525.424.040.648</field>
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale')]"/>
+    </function>
+
+    <record id="demo_nfe_natural_icms_18_resale-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_natural_icms_18_resale"/>
+        <field name="name">Teste</field>
+        <field name="product_id" ref="l10n_br_fiscal.product_resale_nation_origin_ncm_84714900"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="quantity">2</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_revenda"/>
+
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale-1')]"/>
+    </function>
+
 </odoo>

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -239,4 +239,69 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale-1')]"/>
     </function>
 
+
+    <!-- NFe Test - Pessoa Física - ICMS 18% IPI 15% for NCM 94052000 -->
+    <record id="demo_nfe_natural_icms_7_IPI_15" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
+        <field name="document_serie_id" ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"/>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido"/>
+        <field name="company_number">1</field>
+        <field name="document_serie">1</field>
+        <field name="document_section">nfe</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente11_sp"/>
+        <field name="user_id" ref="base.user_demo"/>
+        <field name="partner_legal_name">Cliente 11 SP - PF Não Contribuinte</field>
+        <field name="partner_name">Cliente 11 SP - PF</field>
+        <field name="partner_cnpj_cpf">765.865.078-12</field>
+        <field name="partner_inscr_est">525.424.040.648</field>
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15')]"/>
+    </function>
+
+    <record id="demo_nfe_natural_icms_7_IPI_15-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_natural_icms_7_IPI_15"/>
+        <field name="name">Teste</field>
+        <field name="product_id" ref="l10n_br_fiscal.product_finished_nation_origin_ncm_94052000"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="quantity">2</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+        <field name="cfop_id" ref="l10n_br_fiscal.cfop_6101"/>
+
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+    </function>
+
 </odoo>

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -239,9 +239,8 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale-1')]"/>
     </function>
 
-
     <!-- NFe Test - Pessoa Física - ICMS 18% IPI 15% for NCM 94052000 -->
-    <record id="demo_nfe_natural_icms_7_IPI_15" model="l10n_br_fiscal.document">
+    <record id="demo_nfe_natural_icms_7_IPI_15_sp_am" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"/>
@@ -250,25 +249,25 @@
         <field name="document_serie">1</field>
         <field name="document_section">nfe</field>
         <field name="processador_edoc">oca</field>
-        <field name="partner_id" ref="l10n_br_base.res_partner_cliente11_sp"/>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente4_am"/>
         <field name="user_id" ref="base.user_demo"/>
-        <field name="partner_legal_name">Cliente 11 SP - PF Não Contribuinte</field>
-        <field name="partner_name">Cliente 11 SP - PF</field>
-        <field name="partner_cnpj_cpf">765.865.078-12</field>
-        <field name="partner_inscr_est">525.424.040.648</field>
+        <field name="partner_legal_name">Cliente 11 SP/AM - PF Não Contribuinte</field>
+        <field name="partner_name">Cliente 4 - Z/F Manaus</field>
+        <field name="partner_cnpj_cpf">84.148.732/0001-13</field>
+        <field name="partner_inscr_est">09.569.321-1</field>
         <field name="fiscal_operation_type">out</field>
     </record>
 
     <function model="l10n_br_fiscal.document" name="_onchange_company_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15_sp_am')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15_sp_am')]"/>
     </function>
 
-    <record id="demo_nfe_natural_icms_7_IPI_15-1" model="l10n_br_fiscal.document.line">
-        <field name="document_id" ref="demo_nfe_natural_icms_7_IPI_15"/>
+    <record id="demo_nfe_natural_icms_7_IPI_15_sp_am-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_natural_icms_7_IPI_15_sp_am"/>
         <field name="name">Teste</field>
         <field name="product_id" ref="l10n_br_fiscal.product_finished_nation_origin_ncm_94052000"/>
         <field name="uom_id" ref="uom.product_uom_unit"/>
@@ -280,27 +279,27 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15_sp_am-1')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15_sp_am-1')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15_sp_am-1')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15_sp_am-1')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15_sp_am-1')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15_sp_am-1')]"/>
     </function>
 
     <!-- NFe Test - Pessoa Física - ICMS 4% resale for NCM 94052000 -->

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -114,7 +114,7 @@
 <!--        <value eval="[ref('l10n_br_nfe.demo_nfe_same_state')]"/>-->
 <!--    </function>-->
 
-    <!-- NFe Test - Pessoa Física - ICMS 18% with a reduction of 51.11% for NCM 94013090 -->
+    <!-- NFe Test - Pessoa Física - ICMS 18% with a reduction of 51.11% for NCM 17029000 -->
     <record id="demo_nfe_natural_icms_18_red_51_11" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
@@ -144,7 +144,7 @@
     <record id="demo_nfe_natural_icms_18_red_51_11-1" model="l10n_br_fiscal.document.line">
         <field name="document_id" ref="demo_nfe_natural_icms_18_red_51_11"/>
         <field name="name">Teste</field>
-        <field name="product_id" ref="l10n_br_fiscal.product_finished_nation_origin_ncm_94013090"/>
+        <field name="product_id" ref="l10n_br_fiscal.product_finished_nation_origin_ncm_17029000"/>
         <field name="uom_id" ref="uom.product_uom_unit"/>
         <field name="quantity">1</field>
         <field name="fiscal_operation_type">out</field>
@@ -276,7 +276,6 @@
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
-        <field name="cfop_id" ref="l10n_br_fiscal.cfop_6101"/>
 
     </record>
 

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -303,4 +303,66 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15-1')]"/>
     </function>
 
+    <!-- NFe Test - Pessoa Física - ICMS 4% resale for NCM 94052000 -->
+    <record id="demo_nfe_natural_icms_7_resale" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
+        <field name="document_serie_id" ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"/>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido"/>
+        <field name="company_number">s/n</field>
+        <field name="document_serie">1</field>
+        <field name="document_section">nfe</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente4_am"/>
+        <field name="user_id" ref="base.user_demo"/>
+        <field name="partner_legal_name">Cliente 4 - Manaus</field>
+        <field name="partner_name">Cliente 4 - Z/F Manaus - Simples Nacional</field>
+        <field name="partner_cnpj_cpf">84.148.732/0001-13</field>
+        <field name="partner_inscr_est">09.569.321-1</field>
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale')]"/>
+    </function>
+
+    <record id="demo_nfe_natural_icms_7_resale-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_natural_icms_7_resale"/>
+        <field name="name">Teste</field>
+        <field name="product_id" ref="l10n_br_fiscal.product_resale_nation_origin_ncm_12040090"/>
+        <field name="uom_id" ref="uom.product_uom_kgm"/>
+        <field name="quantity">2</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_revenda"/>
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]"/>
+    </function>
+
 </odoo>

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -426,4 +426,66 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_sp_am-1')]"/>
     </function>
 
+    <!-- NFe Test - Simples Nacional - Same State for NCM 29202400 -->
+    <record id="demo_nfe_simples_nacional_same_state" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
+        <field name="document_serie_id" ref="l10n_br_fiscal.empresa_sn_document_55_serie_1"/>
+        <field name="company_id" ref="l10n_br_base.empresa_simples_nacional"/>
+        <field name="company_number">1</field>
+        <field name="document_serie">1</field>
+        <field name="document_section">nfe</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente11_sp"/>
+        <field name="user_id" ref="base.user_demo"/>
+        <field name="partner_legal_name">Cliente 11 SP - Simples Nacional</field>
+        <field name="partner_name">Cliente 11 SP - PF</field>
+        <field name="partner_cnpj_cpf">765.865.078-12</field>
+        <field name="partner_inscr_est">525.424.040.648</field>
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state')]"/>
+    </function>
+
+    <record id="demo_nfe_simples_nacional_same_state-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_simples_nacional_same_state"/>
+        <field name="name">Sale for Simples Nacional</field>
+        <field name="product_id" ref="l10n_br_fiscal.product_sale_national_origin_ncm_29202400"/>
+        <field name="uom_id" ref="uom.product_uom_kgm"/>
+        <field name="quantity">7.76</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+    </function>
+
 </odoo>

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -426,8 +426,8 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_sp_am-1')]"/>
     </function>
 
-    <!-- NFe Test - Simples Nacional - Same State for NCM 29202400 -->
-    <record id="demo_nfe_simples_nacional_same_state" model="l10n_br_fiscal.document">
+    <!-- NFe Test - Pessoa Física - Same State for NCM 29202400 -->
+    <record id="demo_nfe_national_sale_for_same_state" model="l10n_br_fiscal.document">
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.empresa_sn_document_55_serie_1"/>
@@ -446,16 +446,16 @@
     </record>
 
     <function model="l10n_br_fiscal.document" name="_onchange_company_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state')]"/>
     </function>
 
-    <record id="demo_nfe_simples_nacional_same_state-1" model="l10n_br_fiscal.document.line">
-        <field name="document_id" ref="demo_nfe_simples_nacional_same_state"/>
-        <field name="name">Sale for Simples Nacional</field>
+    <record id="demo_nfe_national_sale_for_same_state-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_national_sale_for_same_state"/>
+        <field name="name">Test Invoice for Sale</field>
         <field name="product_id" ref="l10n_br_fiscal.product_sale_national_origin_ncm_29202400"/>
         <field name="uom_id" ref="uom.product_uom_kgm"/>
         <field name="quantity">7.76</field>
@@ -465,27 +465,27 @@
     </record>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_line_id">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]"/>
     </function>
 
     <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
-        <value eval="[ref('l10n_br_nfe.demo_nfe_simples_nacional_same_state-1')]"/>
+        <value eval="[ref('l10n_br_nfe.demo_nfe_national_sale_for_same_state-1')]"/>
     </function>
 
 </odoo>

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -365,4 +365,66 @@
         <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_resale-1')]"/>
     </function>
 
+    <!-- NFe Test - Pessoa Física - ICMS 7% SP to AM for NCM 94052000 -->
+    <record id="demo_nfe_natural_icms_7_sp_am" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
+        <field name="document_serie_id" ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"/>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido"/>
+        <field name="company_number">s/n</field>
+        <field name="document_serie">1</field>
+        <field name="document_section">nfe</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente4_am"/>
+        <field name="user_id" ref="base.user_demo"/>
+        <field name="partner_legal_name">Cliente 4 - Manaus</field>
+        <field name="partner_name">Cliente 4 - Z/F Manaus - Simples Nacional</field>
+        <field name="partner_cnpj_cpf">84.148.732/0001-13</field>
+        <field name="partner_inscr_est">09.569.321-1</field>
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_sp_am')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_sp_am')]"/>
+    </function>
+
+    <record id="demo_nfe_natural_icms_7_sp_am-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_natural_icms_7_sp_am"/>
+        <field name="name">Teste</field>
+        <field name="product_id" ref="l10n_br_fiscal.product_finished_nation_origin_ncm_22089000"/>
+        <field name="uom_id" ref="uom.product_uom_litre"/>
+        <field name="quantity">2</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_sp_am-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_sp_am-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_sp_am-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_sp_am-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_sp_am-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_7_sp_am-1')]"/>
+    </function>
+
 </odoo>

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -113,4 +113,66 @@
 <!--    <function model="l10n_br_fiscal.document" name="action_document_confirm">-->
 <!--        <value eval="[ref('l10n_br_nfe.demo_nfe_same_state')]"/>-->
 <!--    </function>-->
+
+    <!-- NFe Test - Pessoa Física - ICMS 18% with a reduction of 51.11% for NCM 94013090 -->
+    <record id="demo_nfe_natural_icms_18_red_51_11" model="l10n_br_fiscal.document">
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
+        <field name="document_serie_id" ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"/>
+        <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido"/>
+        <field name="company_number">1</field>
+        <field name="document_serie">1</field>
+        <field name="document_section">nfe</field>
+        <field name="processador_edoc">oca</field>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente11_sp"/>
+        <field name="user_id" ref="base.user_demo"/>
+        <field name="partner_legal_name">Cliente 11 SP - PF Não Contribuinte</field>
+        <field name="partner_name">Cliente 11 SP - PF</field>
+        <field name="partner_cnpj_cpf">765.865.078-12</field>
+        <field name="partner_inscr_est">525.424.040.648</field>
+        <field name="fiscal_operation_type">out</field>
+    </record>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_company_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11')]"/>
+    </function>
+
+    <record id="demo_nfe_natural_icms_18_red_51_11-1" model="l10n_br_fiscal.document.line">
+        <field name="document_id" ref="demo_nfe_natural_icms_18_red_51_11"/>
+        <field name="name">Teste</field>
+        <field name="product_id" ref="l10n_br_fiscal.product_finished_nation_origin_ncm_94013090"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="quantity">1</field>
+        <field name="fiscal_operation_type">out</field>
+        <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
+        <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>
+    </record>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_product_id_fiscal">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_commercial_quantity">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_ncm_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_operation_line_id">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]"/>
+    </function>
+
+    <function model="l10n_br_fiscal.document.line" name="_onchange_fiscal_taxes">
+        <value eval="[ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11-1')]"/>
+    </function>
 </odoo>

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -7,7 +7,7 @@
         <field name="document_type_id" ref="l10n_br_fiscal.document_55"/>
         <field name="document_serie_id" ref="l10n_br_fiscal.empresa_lc_document_55_serie_1"/>
         <field name="company_id" ref="l10n_br_base.empresa_lucro_presumido"/>
-        <field name="company_number">3</field>
+        <field name="company_number">1</field>
         <field name="document_serie">1</field>
         <field name="document_section">nfe</field>
         <field name="processador_edoc">oca</field>

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -458,7 +458,7 @@
         <field name="name">Test Invoice for Sale</field>
         <field name="product_id" ref="l10n_br_fiscal.product_sale_national_origin_ncm_29202400"/>
         <field name="uom_id" ref="uom.product_uom_kgm"/>
-        <field name="quantity">7.76</field>
+        <field name="quantity">2.1</field>
         <field name="fiscal_operation_type">out</field>
         <field name="fiscal_operation_id" ref="l10n_br_fiscal.fo_venda"/>
         <field name="fiscal_operation_line_id" ref="l10n_br_fiscal.fo_venda_venda"/>

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -436,12 +436,12 @@
         <field name="document_serie">1</field>
         <field name="document_section">nfe</field>
         <field name="processador_edoc">oca</field>
-        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp"/>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente1_sp"/>
         <field name="user_id" ref="base.user_demo"/>
-        <field name="partner_legal_name">Cliente 2 - SP</field>
-        <field name="partner_name">Cliente 2 -SP - Simples Nacional</field>
-        <field name="partner_cnpj_cpf">12.046.835/0001-61</field>
-        <field name="partner_inscr_est">887.273.429.152</field>
+        <field name="partner_legal_name">Cliente 1 SP Contribuinte</field>
+        <field name="partner_name">Cliente 1 SP</field>
+        <field name="partner_cnpj_cpf">81.493.979/0001-89</field>
+        <field name="partner_inscr_est">460.429.771.334</field>
         <field name="fiscal_operation_type">out</field>
     </record>
 

--- a/l10n_br_nfe/demo/fiscal_document_demo.xml
+++ b/l10n_br_nfe/demo/fiscal_document_demo.xml
@@ -436,12 +436,12 @@
         <field name="document_serie">1</field>
         <field name="document_section">nfe</field>
         <field name="processador_edoc">oca</field>
-        <field name="partner_id" ref="l10n_br_base.res_partner_cliente11_sp"/>
+        <field name="partner_id" ref="l10n_br_base.res_partner_cliente2_sp"/>
         <field name="user_id" ref="base.user_demo"/>
-        <field name="partner_legal_name">Cliente 11 SP - Simples Nacional</field>
-        <field name="partner_name">Cliente 11 SP - PF</field>
-        <field name="partner_cnpj_cpf">765.865.078-12</field>
-        <field name="partner_inscr_est">525.424.040.648</field>
+        <field name="partner_legal_name">Cliente 2 - SP</field>
+        <field name="partner_name">Cliente 2 -SP - Simples Nacional</field>
+        <field name="partner_cnpj_cpf">12.046.835/0001-61</field>
+        <field name="partner_inscr_est">887.273.429.152</field>
         <field name="fiscal_operation_type">out</field>
     </record>
 

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -382,6 +382,11 @@ class NFeLine(spec_models.StackedModel):
             'vFCPUFDest': str("%.02f" % self.icmsfcp_value),
             'vICMSUFDest': str("%.02f" % self.icms_destination_value),
             'vICMSUFRemet': str("%.02f" % self.icms_origin_value),
+
+            # SIMPLES NACIONAL
+            'CSOSN': self.icms_cst_id.code,
+            'pCredSN': str('%.04f' % self.icmssn_percent),
+            'vCredICMSSN': str("%.02f" % self.icmssn_credit_value),
         }
         return icms
 

--- a/l10n_br_nfe/tests/__init__.py
+++ b/l10n_br_nfe/tests/__init__.py
@@ -6,3 +6,4 @@
 from . import test_nfe_structure
 from . import test_nfe_import
 from . import test_nfe_serialize
+from . import test_nfe_serialize_lc

--- a/l10n_br_nfe/tests/__init__.py
+++ b/l10n_br_nfe/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_nfe_structure
 from . import test_nfe_import
 from . import test_nfe_serialize
 from . import test_nfe_serialize_lc
+from . import test_nfe_serialize_sn

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200697231608000169550010000000111855451724-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200697231608000169550010000000111855451724-nf-e.xml
@@ -1,5 +1,5 @@
 <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
-  <infNFe versao="4.00" Id="NFe35200781583054000129550010000000011062777160">
+  <infNFe versao="4.00" Id="NFeTest">
     <ide>
       <cUF>35</cUF>
       <cNF>06277716</cNF>
@@ -7,8 +7,8 @@
       <mod>55</mod>
       <serie>1</serie>
       <nNF>1</nNF>
-      <dhEmi>2020-06-04T13:58:46+02:00</dhEmi>
-      <dhSaiEnt>2020-06-04T13:58:46+02:00</dhSaiEnt>
+      <dhEmi>2020-01-01T12:00:00+01:00</dhEmi>
+      <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
       <tpNF>1</tpNF>
       <idDest>1</idDest>
       <cMunFG>3550308</cMunFG>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200697231608000169550010000000111855451724-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200697231608000169550010000000111855451724-nf-e.xml
@@ -28,7 +28,7 @@
       <xFant>Empresa Lucro Presumido</xFant>
       <enderEmit>
         <xLgr>Avenida Paulista</xLgr>
-        <nro>3</nro>
+        <nro>1</nro>
         <xBairro>Bela Vista</xBairro>
         <cMun>3550308</cMun>
         <xMun>São Paulo</xMun>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200697231608000169550010000000111855451724-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35200697231608000169550010000000111855451724-nf-e.xml
@@ -14,7 +14,7 @@
       <cMunFG>3550308</cMunFG>
       <tpImp>1</tpImp>
       <tpEmis>1</tpEmis>
-      <cDV>0</cDV>
+      <cDV>1</cDV>
       <tpAmb>2</tpAmb>
       <finNFe>1</finNFe>
       <indFinal>1</indFinal>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210359594315000157550010000000011291881715-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210359594315000157550010000000011291881715-nf-e.xml
@@ -11,7 +11,7 @@
             <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
             <tpNF>1</tpNF>
             <idDest>1</idDest>
-            <cMunFG>3550308</cMunFG>
+            <cMunFG>3501152</cMunFG>
             <tpImp>1</tpImp>
             <tpEmis>1</tpEmis>
             <cDV>5</cDV>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210359594315000157550010000000011291881715-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210359594315000157550010000000011291881715-nf-e.xml
@@ -14,7 +14,7 @@
             <cMunFG>3501152</cMunFG>
             <tpImp>1</tpImp>
             <tpEmis>1</tpEmis>
-            <cDV>5</cDV>
+            <cDV>1</cDV>
             <tpAmb>2</tpAmb>
             <finNFe>1</finNFe>
             <indFinal>1</indFinal>
@@ -139,7 +139,7 @@
                 <vCOFINS>0.00</vCOFINS>
                 <vOutro>0.00</vOutro>
                 <vNF>16.30</vNF>
-                <vTotTrib>4.88</vTotTrib>
+                <vTotTrib>0.00</vTotTrib>
             </ICMSTot>
         </total>
         <transp>
@@ -154,7 +154,7 @@
             <vTroco>0.00</vTroco>
         </pag>
         <infAdic>
-            <infAdFisco>Documento emitido por: Mitchell Admin</infAdFisco>
+            <infAdFisco>Documento emitido por: Marc Demo</infAdFisco>
         </infAdic>
     </infNFe>
 </NFe>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210359594315000157550010000000011291881715-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210359594315000157550010000000011291881715-nf-e.xml
@@ -78,7 +78,7 @@
                 <indTot>1</indTot>
             </prod>
             <imposto>
-                <vTotTrib>4.88</vTotTrib>
+                <vTotTrib>0.00</vTotTrib>
                 <ICMS>
                     <ICMSSN101>
                         <orig>0</orig>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210359594315000157550010000000011291881715-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210359594315000157550010000000011291881715-nf-e.xml
@@ -1,0 +1,160 @@
+<NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+    <infNFe versao="4.00" Id="NFeTest">
+        <ide>
+            <cUF>35</cUF>
+            <cNF>06277716</cNF>
+            <natOp>Venda</natOp>
+            <mod>55</mod>
+            <serie>1</serie>
+            <nNF>1</nNF>
+            <dhEmi>2020-01-01T12:00:00+01:00</dhEmi>
+            <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
+            <tpNF>1</tpNF>
+            <idDest>1</idDest>
+            <cMunFG>3550308</cMunFG>
+            <tpImp>1</tpImp>
+            <tpEmis>1</tpEmis>
+            <cDV>5</cDV>
+            <tpAmb>2</tpAmb>
+            <finNFe>1</finNFe>
+            <indFinal>1</indFinal>
+            <indPres>0</indPres>
+            <procEmi>0</procEmi>
+            <verProc>Odoo Brasil v12.0</verProc>
+        </ide>
+        <emit>
+            <CNPJ>59594315000157</CNPJ>
+            <xNome>TESTE - Simples Nacional</xNome>
+            <xFant>TESTE - Simples Nacional</xFant>
+            <enderEmit>
+                <xLgr>Rua Paulo Dias</xLgr>
+                <nro>586</nro>
+                <cMun>3501152</cMun>
+                <xMun>Alumínio</xMun>
+                <UF>SP</UF>
+                <CEP>18125000</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>2130109965</fone>
+            </enderEmit>
+            <IE>755338250133</IE>
+            <CRT>1</CRT>
+        </emit>
+        <dest>
+            <CNPJ>81493979000189</CNPJ>
+            <xNome>NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL</xNome>
+            <enderDest>
+                <xLgr>Rua Samuel Morse</xLgr>
+                <nro>135</nro>
+                <xCpl>20º andar - Conjunto 151</xCpl>
+                <xBairro>Brooklin</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+                <UF>SP</UF>
+                <CEP>04576060</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>551134782150</fone>
+            </enderDest>
+            <indIEDest>1</indIEDest>
+            <IE>460429771334</IE>
+            <email>cliente1@cliente1.com.br</email>
+        </dest>
+        <det nItem="1">
+            <prod>
+                <cProd>22089000</cProd>
+                <cEAN>SEM GTIN</cEAN>
+                <xProd>[22089000] Sale Product of national origin with NCM 29202400</xProd>
+                <NCM>29202400</NCM>
+                <CFOP>5101</CFOP>
+                <uCom>KG</uCom>
+                <qCom>2.1000</qCom>
+                <vUnCom>7.7600000000</vUnCom>
+                <vProd>16.30</vProd>
+                <cEANTrib>SEM GTIN</cEANTrib>
+                <uTrib>KG</uTrib>
+                <qTrib>2.1000</qTrib>
+                <vUnTrib>7.7600000000</vUnTrib>
+                <indTot>1</indTot>
+            </prod>
+            <imposto>
+                <vTotTrib>4.88</vTotTrib>
+                <ICMS>
+                    <ICMSSN101>
+                        <orig>0</orig>
+                        <CSOSN>101</CSOSN>
+                        <pCredSN>2.7000</pCredSN>
+                        <vCredICMSSN>0.44</vCredICMSSN>
+                    </ICMSSN101>
+                </ICMS>
+                <IPI>
+                    <cEnq>999</cEnq>
+                    <IPITrib>
+                        <CST>99</CST>
+                        <vBC>0.00</vBC>
+                        <pIPI>0.0000</pIPI>
+                        <vIPI>0.00</vIPI>
+                    </IPITrib>
+                </IPI>
+                <PIS>
+                    <PISOutr>
+                        <CST>49</CST>
+                        <vBC>0.00</vBC>
+                        <pPIS>0.0000</pPIS>
+                        <vPIS>0.00</vPIS>
+                    </PISOutr>
+                </PIS>
+                <COFINS>
+                    <COFINSOutr>
+                        <CST>49</CST>
+                        <vBC>0.00</vBC>
+                        <pCOFINS>0.0000</pCOFINS>
+                        <vCOFINS>0.00</vCOFINS>
+                    </COFINSOutr>
+                </COFINS>
+            </imposto>
+            <infAdProd>Val Aprox Tributos Federal R$ 0.00</infAdProd>
+        </det>
+        <total>
+            <ICMSTot>
+                <vBC>0.00</vBC>
+                <vICMS>0.00</vICMS>
+                <vICMSDeson>0.00</vICMSDeson>
+                <vFCPUFDest>0.00</vFCPUFDest>
+                <vICMSUFDest>0.00</vICMSUFDest>
+                <vICMSUFRemet>0.00</vICMSUFRemet>
+                <vFCP>0.00</vFCP>
+                <vBCST>0.00</vBCST>
+                <vST>0.00</vST>
+                <vFCPST>0.00</vFCPST>
+                <vFCPSTRet>0.00</vFCPSTRet>
+                <vProd>16.30</vProd>
+                <vFrete>0.00</vFrete>
+                <vSeg>0.00</vSeg>
+                <vDesc>0.00</vDesc>
+                <vII>0.00</vII>
+                <vIPI>0.00</vIPI>
+                <vIPIDevol>0.00</vIPIDevol>
+                <vPIS>0.00</vPIS>
+                <vCOFINS>0.00</vCOFINS>
+                <vOutro>0.00</vOutro>
+                <vNF>16.30</vNF>
+                <vTotTrib>4.88</vTotTrib>
+            </ICMSTot>
+        </total>
+        <transp>
+            <modFrete>9</modFrete>
+        </transp>
+        <pag>
+            <detPag>
+                <indPag>0</indPag>
+                <tPag>99</tPag>
+                <vPag>16.30</vPag>
+            </detPag>
+            <vTroco>0.00</vTroco>
+        </pag>
+        <infAdic>
+            <infAdFisco>Documento emitido por: Mitchell Admin</infAdFisco>
+        </infAdic>
+    </infNFe>
+</NFe>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000011659437930-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000011659437930-nf-e.xml
@@ -14,7 +14,7 @@
             <cMunFG>3550308</cMunFG>
             <tpImp>1</tpImp>
             <tpEmis>1</tpEmis>
-            <cDV>0</cDV>
+            <cDV>1</cDV>
             <tpAmb>2</tpAmb>
             <finNFe>1</finNFe>
             <indFinal>1</indFinal>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000011659437930-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000011659437930-nf-e.xml
@@ -10,7 +10,7 @@
             <dhEmi>2020-01-01T12:00:00+01:00</dhEmi>
             <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
             <tpNF>1</tpNF>
-            <idDest>1</idDest>
+            <idDest>2</idDest>
             <cMunFG>3550308</cMunFG>
             <tpImp>1</tpImp>
             <tpEmis>1</tpEmis>
@@ -28,7 +28,6 @@
             <xFant>Empresa Lucro Presumido</xFant>
             <enderEmit>
                 <xLgr>Avenida Paulista</xLgr>
-                <nro>1</nro>
                 <xBairro>Bela Vista</xBairro>
                 <cMun>3550308</cMun>
                 <xMun>São Paulo</xMun>
@@ -42,36 +41,39 @@
             <CRT>3</CRT>
         </emit>
         <dest>
-            <CPF>76586507812</CPF>
+            <CNPJ>84148732000113</CNPJ>
             <xNome>NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL</xNome>
             <enderDest>
-                <xLgr>Rua do Bosque</xLgr>
-                <nro>238</nro>
-                <xBairro>Barra Funda</xBairro>
-                <cMun>3550308</cMun>
-                <xMun>São Paulo</xMun>
-                <UF>SP</UF>
-                <CEP>01136000</CEP>
+                <xLgr>Avenida Javari</xLgr>
+                <nro>s/n</nro>
+                <xCpl>Lote 9.45/15E</xCpl>
+                <xBairro>Distrito Industrial</xBairro>
+                <cMun>1302603</cMun>
+                <xMun>Manaus</xMun>
+                <UF>AM</UF>
+                <CEP>69075110</CEP>
                 <cPais>1058</cPais>
                 <xPais>Brasil</xPais>
-                <fone>1138817417</fone>
+                <fone>9221458888</fone>
             </enderDest>
-            <indIEDest>9</indIEDest>
-            <email>cliente11@cliente11.com.br</email>
+            <indIEDest>1</indIEDest>
+            <IE>095693211</IE>
+            <ISUF>100695108</ISUF>
+            <email>cliente4@cliente4.com.br</email>
         </dest>
         <det nItem="1">
             <prod>
-                <cProd>84714900</cProd>
+                <cProd>12040090</cProd>
                 <cEAN>SEM GTIN</cEAN>
-                <xProd>[84714900] Resale Product of national origin NCM 84714900</xProd>
-                <NCM>84714900</NCM>
-                <CFOP>5102</CFOP>
-                <uCom>UNID</uCom>
+                <xProd>[12040090] Resale Product of national origin NCM 12040090</xProd>
+                <NCM>12040090</NCM>
+                <CFOP>6102</CFOP>
+                <uCom>KG</uCom>
                 <qCom>2.0000</qCom>
                 <vUnCom>80.0000000000</vUnCom>
                 <vProd>160.00</vProd>
                 <cEANTrib>SEM GTIN</cEANTrib>
-                <uTrib>UNID</uTrib>
+                <uTrib>KG</uTrib>
                 <qTrib>2.0000</qTrib>
                 <vUnTrib>80.0000000000</vUnTrib>
                 <indTot>1</indTot>
@@ -80,12 +82,12 @@
                 <vTotTrib>0.00</vTotTrib>
                 <ICMS>
                     <ICMS00>
-                        <orig>0</orig>
+                        <orig>2</orig>
                         <CST>00</CST>
                         <modBC>0</modBC>
                         <vBC>160.00</vBC>
-                        <pICMS>18.0000</pICMS>
-                        <vICMS>28.80</vICMS>
+                        <pICMS>4.0000</pICMS>
+                        <vICMS>6.40</vICMS>
                     </ICMS00>
                 </ICMS>
                 <IPI>
@@ -115,7 +117,7 @@
         <total>
             <ICMSTot>
                 <vBC>160.00</vBC>
-                <vICMS>28.80</vICMS>
+                <vICMS>6.40</vICMS>
                 <vICMSDeson>0.00</vICMSDeson>
                 <vFCPUFDest>0.00</vFCPUFDest>
                 <vICMSUFDest>0.00</vICMSUFDest>
@@ -151,7 +153,7 @@
             <vTroco>0.00</vTroco>
         </pag>
         <infAdic>
-            <infAdFisco>Documento emitido por: Marc Demo, Documento emitido por: Marc Demo</infAdFisco>
+            <infAdFisco>Documento emitido por: Marc Demo</infAdFisco>
         </infAdic>
     </infNFe>
 </NFe>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000011659437930-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000011659437930-nf-e.xml
@@ -28,6 +28,7 @@
             <xFant>Empresa Lucro Presumido</xFant>
             <enderEmit>
                 <xLgr>Avenida Paulista</xLgr>
+                <nro>1</nro>
                 <xBairro>Bela Vista</xBairro>
                 <cMun>3550308</cMun>
                 <xMun>São Paulo</xMun>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000011659437930-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000011659437930-nf-e.xml
@@ -1,0 +1,157 @@
+<NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+    <infNFe versao="4.00" Id="NFeTest">
+        <ide>
+            <cUF>35</cUF>
+            <cNF>06277716</cNF>
+            <natOp>Venda</natOp>
+            <mod>55</mod>
+            <serie>1</serie>
+            <nNF>1</nNF>
+            <dhEmi>2020-01-01T12:00:00+01:00</dhEmi>
+            <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
+            <tpNF>1</tpNF>
+            <idDest>1</idDest>
+            <cMunFG>3550308</cMunFG>
+            <tpImp>1</tpImp>
+            <tpEmis>1</tpEmis>
+            <cDV>0</cDV>
+            <tpAmb>2</tpAmb>
+            <finNFe>1</finNFe>
+            <indFinal>1</indFinal>
+            <indPres>0</indPres>
+            <procEmi>0</procEmi>
+            <verProc>Odoo Brasil v12.0</verProc>
+        </ide>
+        <emit>
+            <CNPJ>81583054000129</CNPJ>
+            <xNome>Empresa Lucro Presumido Ltda</xNome>
+            <xFant>Empresa Lucro Presumido</xFant>
+            <enderEmit>
+                <xLgr>Avenida Paulista</xLgr>
+                <nro>1</nro>
+                <xBairro>Bela Vista</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+                <UF>SP</UF>
+                <CEP>01311000</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>551199999999</fone>
+            </enderEmit>
+            <IE>078016350838</IE>
+            <CRT>3</CRT>
+        </emit>
+        <dest>
+            <CPF>76586507812</CPF>
+            <xNome>NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL</xNome>
+            <enderDest>
+                <xLgr>Rua do Bosque</xLgr>
+                <nro>238</nro>
+                <xBairro>Barra Funda</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+                <UF>SP</UF>
+                <CEP>01136000</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>1138817417</fone>
+            </enderDest>
+            <indIEDest>9</indIEDest>
+            <email>cliente11@cliente11.com.br</email>
+        </dest>
+        <det nItem="1">
+            <prod>
+                <cProd>84714900</cProd>
+                <cEAN>SEM GTIN</cEAN>
+                <xProd>[84714900] Resale Product of national origin NCM 84714900</xProd>
+                <NCM>84714900</NCM>
+                <CFOP>5102</CFOP>
+                <uCom>UNID</uCom>
+                <qCom>2.0000</qCom>
+                <vUnCom>80.0000000000</vUnCom>
+                <vProd>160.00</vProd>
+                <cEANTrib>SEM GTIN</cEANTrib>
+                <uTrib>UNID</uTrib>
+                <qTrib>2.0000</qTrib>
+                <vUnTrib>80.0000000000</vUnTrib>
+                <indTot>1</indTot>
+            </prod>
+            <imposto>
+                <vTotTrib>0.00</vTotTrib>
+                <ICMS>
+                    <ICMS00>
+                        <orig>0</orig>
+                        <CST>00</CST>
+                        <modBC>0</modBC>
+                        <vBC>160.00</vBC>
+                        <pICMS>18.0000</pICMS>
+                        <vICMS>28.80</vICMS>
+                    </ICMS00>
+                </ICMS>
+                <IPI>
+                    <cEnq>999</cEnq>
+                    <IPINT>
+                        <CST>53</CST>
+                    </IPINT>
+                </IPI>
+                <PIS>
+                    <PISAliq>
+                        <CST>01</CST>
+                        <vBC>160.00</vBC>
+                        <pPIS>0.6500</pPIS>
+                        <vPIS>1.04</vPIS>
+                    </PISAliq>
+                </PIS>
+                <COFINS>
+                    <COFINSAliq>
+                        <CST>01</CST>
+                        <vBC>160.00</vBC>
+                        <pCOFINS>3.0000</pCOFINS>
+                        <vCOFINS>4.80</vCOFINS>
+                    </COFINSAliq>
+                </COFINS>
+            </imposto>
+        </det>
+        <total>
+            <ICMSTot>
+                <vBC>160.00</vBC>
+                <vICMS>28.80</vICMS>
+                <vICMSDeson>0.00</vICMSDeson>
+                <vFCPUFDest>0.00</vFCPUFDest>
+                <vICMSUFDest>0.00</vICMSUFDest>
+                <vICMSUFRemet>0.00</vICMSUFRemet>
+                <vFCP>0.00</vFCP>
+                <vBCST>0.00</vBCST>
+                <vST>0.00</vST>
+                <vFCPST>0.00</vFCPST>
+                <vFCPSTRet>0.00</vFCPSTRet>
+                <vProd>160.00</vProd>
+                <vFrete>0.00</vFrete>
+                <vSeg>0.00</vSeg>
+                <vDesc>0.00</vDesc>
+                <vII>0.00</vII>
+                <vIPI>0.00</vIPI>
+                <vIPIDevol>0.00</vIPIDevol>
+                <vPIS>1.04</vPIS>
+                <vCOFINS>4.80</vCOFINS>
+                <vOutro>0.00</vOutro>
+                <vNF>160.00</vNF>
+                <vTotTrib>0.00</vTotTrib>
+            </ICMSTot>
+        </total>
+        <transp>
+            <modFrete>9</modFrete>
+        </transp>
+        <pag>
+            <detPag>
+                <indPag>0</indPag>
+                <tPag>99</tPag>
+                <vPag>160.00</vPag>
+            </detPag>
+            <vTroco>0.00</vTroco>
+        </pag>
+        <infAdic>
+            <infAdFisco>Documento emitido por: Marc Demo, Documento emitido por: Marc Demo</infAdFisco>
+        </infAdic>
+    </infNFe>
+</NFe>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000021659443040-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000021659443040-nf-e.xml
@@ -14,7 +14,7 @@
             <cMunFG>3550308</cMunFG>
             <tpImp>1</tpImp>
             <tpEmis>1</tpEmis>
-            <cDV>0</cDV>
+            <cDV>1</cDV>
             <tpAmb>2</tpAmb>
             <finNFe>1</finNFe>
             <indFinal>1</indFinal>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000021659443040-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000021659443040-nf-e.xml
@@ -115,7 +115,7 @@
                     </COFINSAliq>
                 </COFINS>
             </imposto>
-            <infAdProd>Val Aprox Tributos Federal R$ 36,43</infAdProd>
+            <infAdProd>Val Aprox Tributos Federal R$ 36.43</infAdProd>
         </det>
         <total>
             <ICMSTot>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000021659443040-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000021659443040-nf-e.xml
@@ -28,7 +28,6 @@
             <xFant>Empresa Lucro Presumido</xFant>
             <enderEmit>
                 <xLgr>Avenida Paulista</xLgr>
-                <nro>1</nro>
                 <xBairro>Bela Vista</xBairro>
                 <cMun>3550308</cMun>
                 <xMun>São Paulo</xMun>
@@ -61,17 +60,17 @@
         </dest>
         <det nItem="1">
             <prod>
-                <cProd>94013090</cProd>
+                <cProd>17029000</cProd>
                 <cEAN>SEM GTIN</cEAN>
-                <xProd>[94013090] Finished Product of national origin NCM 94013090</xProd>
-                <NCM>94013090</NCM>
+                <xProd>[17029000] Finished Product of national origin NCM 17029000</xProd>
+                <NCM>17029000</NCM>
                 <CFOP>5101</CFOP>
-                <uCom>UNID</uCom>
+                <uCom>KG</uCom>
                 <qCom>1.0000</qCom>
                 <vUnCom>728.5700000000</vUnCom>
                 <vProd>728.57</vProd>
                 <cEANTrib>SEM GTIN</cEANTrib>
-                <uTrib>UNID</uTrib>
+                <uTrib>KG</uTrib>
                 <qTrib>1.0000</qTrib>
                 <vUnTrib>728.5700000000</vUnTrib>
                 <indTot>1</indTot>
@@ -115,7 +114,7 @@
                     </COFINSAliq>
                 </COFINS>
             </imposto>
-            <infAdProd>Val Aprox Tributos Federal R$ 36.43</infAdProd>
+            <infAdProd>Val Aprox Tributos Federal R$ 36,43</infAdProd>
         </det>
         <total>
             <ICMSTot>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000021659443040-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000021659443040-nf-e.xml
@@ -28,6 +28,7 @@
             <xFant>Empresa Lucro Presumido</xFant>
             <enderEmit>
                 <xLgr>Avenida Paulista</xLgr>
+                <nro>1</nro>
                 <xBairro>Bela Vista</xBairro>
                 <cMun>3550308</cMun>
                 <xMun>São Paulo</xMun>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000021659443040-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000021659443040-nf-e.xml
@@ -1,0 +1,162 @@
+<NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+    <infNFe versao="4.00" Id="NFeTest">
+        <ide>
+            <cUF>35</cUF>
+            <cNF>06277716</cNF>
+            <natOp>Venda</natOp>
+            <mod>55</mod>
+            <serie>1</serie>
+            <nNF>1</nNF>
+            <dhEmi>2020-01-01T12:00:00+01:00</dhEmi>
+            <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
+            <tpNF>1</tpNF>
+            <idDest>1</idDest>
+            <cMunFG>3550308</cMunFG>
+            <tpImp>1</tpImp>
+            <tpEmis>1</tpEmis>
+            <cDV>0</cDV>
+            <tpAmb>2</tpAmb>
+            <finNFe>1</finNFe>
+            <indFinal>1</indFinal>
+            <indPres>0</indPres>
+            <procEmi>0</procEmi>
+            <verProc>Odoo Brasil v12.0</verProc>
+        </ide>
+        <emit>
+            <CNPJ>81583054000129</CNPJ>
+            <xNome>Empresa Lucro Presumido Ltda</xNome>
+            <xFant>Empresa Lucro Presumido</xFant>
+            <enderEmit>
+                <xLgr>Avenida Paulista</xLgr>
+                <nro>1</nro>
+                <xBairro>Bela Vista</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+                <UF>SP</UF>
+                <CEP>01311000</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>551199999999</fone>
+            </enderEmit>
+            <IE>078016350838</IE>
+            <CRT>3</CRT>
+        </emit>
+        <dest>
+            <CPF>76586507812</CPF>
+            <xNome>NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL</xNome>
+            <enderDest>
+                <xLgr>Rua do Bosque</xLgr>
+                <nro>238</nro>
+                <xBairro>Barra Funda</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+                <UF>SP</UF>
+                <CEP>01136000</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>1138817417</fone>
+            </enderDest>
+            <indIEDest>9</indIEDest>
+            <email>cliente11@cliente11.com.br</email>
+        </dest>
+        <det nItem="1">
+            <prod>
+                <cProd>94013090</cProd>
+                <cEAN>SEM GTIN</cEAN>
+                <xProd>[94013090] Finished Product of national origin NCM 94013090</xProd>
+                <NCM>94013090</NCM>
+                <CFOP>5101</CFOP>
+                <uCom>UNID</uCom>
+                <qCom>1.0000</qCom>
+                <vUnCom>728.5700000000</vUnCom>
+                <vProd>728.57</vProd>
+                <cEANTrib>SEM GTIN</cEANTrib>
+                <uTrib>UNID</uTrib>
+                <qTrib>1.0000</qTrib>
+                <vUnTrib>728.5700000000</vUnTrib>
+                <indTot>1</indTot>
+            </prod>
+            <imposto>
+                <vTotTrib>0.00</vTotTrib>
+                <ICMS>
+                    <ICMS20>
+                        <orig>0</orig>
+                        <CST>20</CST>
+                        <modBC>0</modBC>
+                        <pRedBC>51.1100</pRedBC>
+                        <vBC>374.01</vBC>
+                        <pICMS>18.0000</pICMS>
+                        <vICMS>67.32</vICMS>
+                    </ICMS20>
+                </ICMS>
+                <IPI>
+                    <cEnq>999</cEnq>
+                    <IPITrib>
+                        <CST>50</CST>
+                        <vBC>728.57</vBC>
+                        <pIPI>5.0000</pIPI>
+                        <vIPI>36.43</vIPI>
+                    </IPITrib>
+                </IPI>
+                <PIS>
+                    <PISAliq>
+                        <CST>01</CST>
+                        <vBC>728.57</vBC>
+                        <pPIS>0.6500</pPIS>
+                        <vPIS>4.74</vPIS>
+                    </PISAliq>
+                </PIS>
+                <COFINS>
+                    <COFINSAliq>
+                        <CST>01</CST>
+                        <vBC>728.57</vBC>
+                        <pCOFINS>3.0000</pCOFINS>
+                        <vCOFINS>21.86</vCOFINS>
+                    </COFINSAliq>
+                </COFINS>
+            </imposto>
+            <infAdProd>Val Aprox Tributos Federal R$ 36.43</infAdProd>
+        </det>
+        <total>
+            <ICMSTot>
+                <vBC>374.01</vBC>
+                <vICMS>67.32</vICMS>
+                <vICMSDeson>0.00</vICMSDeson>
+                <vFCPUFDest>0.00</vFCPUFDest>
+                <vICMSUFDest>0.00</vICMSUFDest>
+                <vICMSUFRemet>0.00</vICMSUFRemet>
+                <vFCP>0.00</vFCP>
+                <vBCST>0.00</vBCST>
+                <vST>0.00</vST>
+                <vFCPST>0.00</vFCPST>
+                <vFCPSTRet>0.00</vFCPSTRet>
+                <vProd>728.57</vProd>
+                <vFrete>0.00</vFrete>
+                <vSeg>0.00</vSeg>
+                <vDesc>0.00</vDesc>
+                <vII>0.00</vII>
+                <vIPI>36.43</vIPI>
+                <vIPIDevol>0.00</vIPIDevol>
+                <vPIS>4.74</vPIS>
+                <vCOFINS>21.86</vCOFINS>
+                <vOutro>0.00</vOutro>
+                <vNF>765.00</vNF>
+                <vTotTrib>0.00</vTotTrib>
+            </ICMSTot>
+        </total>
+        <transp>
+            <modFrete>9</modFrete>
+        </transp>
+        <pag>
+            <detPag>
+                <indPag>0</indPag>
+                <tPag>99</tPag>
+                <vPag>765.00</vPag>
+            </detPag>
+            <vTroco>0.00</vTroco>
+        </pag>
+        <infAdic>
+            <infAdFisco>Documento emitido por: Marc Demo</infAdFisco>
+        </infAdic>
+    </infNFe>
+</NFe>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000031659634756-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000031659634756-nf-e.xml
@@ -1,0 +1,161 @@
+<NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+    <infNFe versao="4.00" Id="NFeTest">
+        <ide>
+            <cUF>35</cUF>
+            <cNF>06277716</cNF>
+            <natOp>Venda</natOp>
+            <mod>55</mod>
+            <serie>1</serie>
+            <nNF>1</nNF>
+            <dhEmi>2020-01-01T12:00:00+01:00</dhEmi>
+            <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
+            <tpNF>1</tpNF>
+            <idDest>1</idDest>
+            <cMunFG>3550308</cMunFG>
+            <tpImp>1</tpImp>
+            <tpEmis>1</tpEmis>
+            <cDV>6</cDV>
+            <tpAmb>2</tpAmb>
+            <finNFe>1</finNFe>
+            <indFinal>1</indFinal>
+            <indPres>0</indPres>
+            <procEmi>0</procEmi>
+            <verProc>Odoo Brasil v12.0</verProc>
+        </ide>
+        <emit>
+            <CNPJ>81583054000129</CNPJ>
+            <xNome>Empresa Lucro Presumido Ltda</xNome>
+            <xFant>Empresa Lucro Presumido</xFant>
+            <enderEmit>
+                <xLgr>Avenida Paulista</xLgr>
+                <nro>1</nro>
+                <xBairro>Bela Vista</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+                <UF>SP</UF>
+                <CEP>01311000</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>551199999999</fone>
+            </enderEmit>
+            <IE>078016350838</IE>
+            <CRT>3</CRT>
+        </emit>
+        <dest>
+            <CPF>76586507812</CPF>
+            <xNome>NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL</xNome>
+            <enderDest>
+                <xLgr>Rua do Bosque</xLgr>
+                <nro>238</nro>
+                <xBairro>Barra Funda</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+                <UF>SP</UF>
+                <CEP>01136000</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>1138817417</fone>
+            </enderDest>
+            <indIEDest>9</indIEDest>
+            <email>cliente11@cliente11.com.br</email>
+        </dest>
+        <det nItem="1">
+            <prod>
+                <cProd>94052000</cProd>
+                <cEAN>SEM GTIN</cEAN>
+                <xProd>[94052000] Finished Product of national origin NCM 94052000</xProd>
+                <NCM>94052000</NCM>
+                <CFOP>5101</CFOP>
+                <uCom>UNID</uCom>
+                <qCom>2.0000</qCom>
+                <vUnCom>234.0000000000</vUnCom>
+                <vProd>468.00</vProd>
+                <cEANTrib>SEM GTIN</cEANTrib>
+                <uTrib>UNID</uTrib>
+                <qTrib>2.0000</qTrib>
+                <vUnTrib>234.0000000000</vUnTrib>
+                <indTot>1</indTot>
+            </prod>
+            <imposto>
+                <vTotTrib>0.00</vTotTrib>
+                <ICMS>
+                    <ICMS00>
+                        <orig>0</orig>
+                        <CST>00</CST>
+                        <modBC>0</modBC>
+                        <vBC>538.20</vBC>
+                        <pICMS>7.0000</pICMS>
+                        <vICMS>37.67</vICMS>
+                    </ICMS00>
+                </ICMS>
+                <IPI>
+                    <cEnq>999</cEnq>
+                    <IPITrib>
+                        <CST>50</CST>
+                        <vBC>468.00</vBC>
+                        <pIPI>15.0000</pIPI>
+                        <vIPI>70.20</vIPI>
+                    </IPITrib>
+                </IPI>
+                <PIS>
+                    <PISAliq>
+                        <CST>01</CST>
+                        <vBC>468.00</vBC>
+                        <pPIS>0.6500</pPIS>
+                        <vPIS>3.04</vPIS>
+                    </PISAliq>
+                </PIS>
+                <COFINS>
+                    <COFINSAliq>
+                        <CST>01</CST>
+                        <vBC>468.00</vBC>
+                        <pCOFINS>3.0000</pCOFINS>
+                        <vCOFINS>14.04</vCOFINS>
+                    </COFINSAliq>
+                </COFINS>
+            </imposto>
+            <infAdProd>Val Aprox Tributos Federal R$ 70.20</infAdProd>
+        </det>
+        <total>
+            <ICMSTot>
+                <vBC>538.20</vBC>
+                <vICMS>37.67</vICMS>
+                <vICMSDeson>0.00</vICMSDeson>
+                <vFCPUFDest>0.00</vFCPUFDest>
+                <vICMSUFDest>0.00</vICMSUFDest>
+                <vICMSUFRemet>0.00</vICMSUFRemet>
+                <vFCP>0.00</vFCP>
+                <vBCST>0.00</vBCST>
+                <vST>0.00</vST>
+                <vFCPST>0.00</vFCPST>
+                <vFCPSTRet>0.00</vFCPSTRet>
+                <vProd>468.00</vProd>
+                <vFrete>0.00</vFrete>
+                <vSeg>0.00</vSeg>
+                <vDesc>0.00</vDesc>
+                <vII>0.00</vII>
+                <vIPI>70.20</vIPI>
+                <vIPIDevol>0.00</vIPIDevol>
+                <vPIS>3.04</vPIS>
+                <vCOFINS>14.04</vCOFINS>
+                <vOutro>0.00</vOutro>
+                <vNF>538.20</vNF>
+                <vTotTrib>0.00</vTotTrib>
+            </ICMSTot>
+        </total>
+        <transp>
+            <modFrete>9</modFrete>
+        </transp>
+        <pag>
+            <detPag>
+                <indPag>0</indPag>
+                <tPag>99</tPag>
+                <vPag>538.20</vPag>
+            </detPag>
+            <vTroco>0.00</vTroco>
+        </pag>
+        <infAdic>
+            <infAdFisco>Documento emitido por: Marc Demo</infAdFisco>
+        </infAdic>
+    </infNFe>
+</NFe>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000031659634756-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000031659634756-nf-e.xml
@@ -10,11 +10,11 @@
             <dhEmi>2020-01-01T12:00:00+01:00</dhEmi>
             <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
             <tpNF>1</tpNF>
-            <idDest>2</idDest>
+            <idDest>1</idDest>
             <cMunFG>3550308</cMunFG>
             <tpImp>1</tpImp>
             <tpEmis>1</tpEmis>
-            <cDV>0</cDV>
+            <cDV>6</cDV>
             <tpAmb>2</tpAmb>
             <finNFe>1</finNFe>
             <indFinal>1</indFinal>
@@ -41,41 +41,38 @@
             <CRT>3</CRT>
         </emit>
         <dest>
-            <CNPJ>84148732000113</CNPJ>
+            <CPF>76586507812</CPF>
             <xNome>NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL</xNome>
             <enderDest>
-                <xLgr>Avenida Javari</xLgr>
-                <nro>s/n</nro>
-                <xCpl>Lote 9.45/15E</xCpl>
-                <xBairro>Distrito Industrial</xBairro>
-                <cMun>1302603</cMun>
-                <xMun>Manaus</xMun>
-                <UF>AM</UF>
-                <CEP>69075110</CEP>
+                <xLgr>Rua do Bosque</xLgr>
+                <nro>238</nro>
+                <xBairro>Barra Funda</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+                <UF>SP</UF>
+                <CEP>01136000</CEP>
                 <cPais>1058</cPais>
                 <xPais>Brasil</xPais>
-                <fone>9221458888</fone>
+                <fone>1138817417</fone>
             </enderDest>
-            <indIEDest>1</indIEDest>
-            <IE>095693211</IE>
-            <ISUF>100695108</ISUF>
-            <email>cliente4@cliente4.com.br</email>
+            <indIEDest>9</indIEDest>
+            <email>cliente11@cliente11.com.br</email>
         </dest>
         <det nItem="1">
             <prod>
-                <cProd>94052000</cProd>
+                <cProd>84714900</cProd>
                 <cEAN>SEM GTIN</cEAN>
-                <xProd>[94052000] Finished Product of national origin NCM 94052000</xProd>
-                <NCM>94052000</NCM>
-                <CFOP>6101</CFOP>
+                <xProd>[84714900] Resale Product of national origin NCM 84714900</xProd>
+                <NCM>84714900</NCM>
+                <CFOP>5102</CFOP>
                 <uCom>UNID</uCom>
                 <qCom>2.0000</qCom>
-                <vUnCom>234.0000000000</vUnCom>
-                <vProd>468.00</vProd>
+                <vUnCom>80.0000000000</vUnCom>
+                <vProd>160.00</vProd>
                 <cEANTrib>SEM GTIN</cEANTrib>
                 <uTrib>UNID</uTrib>
                 <qTrib>2.0000</qTrib>
-                <vUnTrib>234.0000000000</vUnTrib>
+                <vUnTrib>80.0000000000</vUnTrib>
                 <indTot>1</indTot>
             </prod>
             <imposto>
@@ -85,43 +82,39 @@
                         <orig>0</orig>
                         <CST>00</CST>
                         <modBC>0</modBC>
-                        <vBC>538.20</vBC>
-                        <pICMS>7.0000</pICMS>
-                        <vICMS>37.67</vICMS>
+                        <vBC>160.00</vBC>
+                        <pICMS>18.0000</pICMS>
+                        <vICMS>28.80</vICMS>
                     </ICMS00>
                 </ICMS>
                 <IPI>
                     <cEnq>999</cEnq>
-                    <IPITrib>
-                        <CST>50</CST>
-                        <vBC>468.00</vBC>
-                        <pIPI>15.0000</pIPI>
-                        <vIPI>70.20</vIPI>
-                    </IPITrib>
+                    <IPINT>
+                        <CST>53</CST>
+                    </IPINT>
                 </IPI>
                 <PIS>
                     <PISAliq>
                         <CST>01</CST>
-                        <vBC>468.00</vBC>
+                        <vBC>160.00</vBC>
                         <pPIS>0.6500</pPIS>
-                        <vPIS>3.04</vPIS>
+                        <vPIS>1.04</vPIS>
                     </PISAliq>
                 </PIS>
                 <COFINS>
                     <COFINSAliq>
                         <CST>01</CST>
-                        <vBC>468.00</vBC>
+                        <vBC>160.00</vBC>
                         <pCOFINS>3.0000</pCOFINS>
-                        <vCOFINS>14.04</vCOFINS>
+                        <vCOFINS>4.80</vCOFINS>
                     </COFINSAliq>
                 </COFINS>
             </imposto>
-            <infAdProd>Val Aprox Tributos Federal R$ 70,20</infAdProd>
         </det>
         <total>
             <ICMSTot>
-                <vBC>538.20</vBC>
-                <vICMS>37.67</vICMS>
+                <vBC>160.00</vBC>
+                <vICMS>28.80</vICMS>
                 <vICMSDeson>0.00</vICMSDeson>
                 <vFCPUFDest>0.00</vFCPUFDest>
                 <vICMSUFDest>0.00</vICMSUFDest>
@@ -131,17 +124,17 @@
                 <vST>0.00</vST>
                 <vFCPST>0.00</vFCPST>
                 <vFCPSTRet>0.00</vFCPSTRet>
-                <vProd>468.00</vProd>
+                <vProd>160.00</vProd>
                 <vFrete>0.00</vFrete>
                 <vSeg>0.00</vSeg>
                 <vDesc>0.00</vDesc>
                 <vII>0.00</vII>
-                <vIPI>70.20</vIPI>
+                <vIPI>0.00</vIPI>
                 <vIPIDevol>0.00</vIPIDevol>
-                <vPIS>3.04</vPIS>
-                <vCOFINS>14.04</vCOFINS>
+                <vPIS>1.04</vPIS>
+                <vCOFINS>4.80</vCOFINS>
                 <vOutro>0.00</vOutro>
-                <vNF>538.20</vNF>
+                <vNF>160.00</vNF>
                 <vTotTrib>0.00</vTotTrib>
             </ICMSTot>
         </total>
@@ -152,7 +145,7 @@
             <detPag>
                 <indPag>0</indPag>
                 <tPag>99</tPag>
-                <vPag>538.20</vPag>
+                <vPag>160.00</vPag>
             </detPag>
             <vTroco>0.00</vTroco>
         </pag>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000031659634756-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000031659634756-nf-e.xml
@@ -14,7 +14,7 @@
             <cMunFG>3550308</cMunFG>
             <tpImp>1</tpImp>
             <tpEmis>1</tpEmis>
-            <cDV>6</cDV>
+            <cDV>1</cDV>
             <tpAmb>2</tpAmb>
             <finNFe>1</finNFe>
             <indFinal>1</indFinal>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000031659634756-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000031659634756-nf-e.xml
@@ -28,6 +28,7 @@
             <xFant>Empresa Lucro Presumido</xFant>
             <enderEmit>
                 <xLgr>Avenida Paulista</xLgr>
+                <nro>1</nro>
                 <xBairro>Bela Vista</xBairro>
                 <cMun>3550308</cMun>
                 <xMun>São Paulo</xMun>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000041662059365-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000041662059365-nf-e.xml
@@ -6,7 +6,7 @@
             <natOp>Venda</natOp>
             <mod>55</mod>
             <serie>1</serie>
-            <nNF>3</nNF>
+            <nNF>1</nNF>
             <dhEmi>2020-01-01T12:00:00+01:00</dhEmi>
             <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
             <tpNF>1</tpNF>
@@ -14,7 +14,7 @@
             <cMunFG>3550308</cMunFG>
             <tpImp>1</tpImp>
             <tpEmis>1</tpEmis>
-            <cDV>6</cDV>
+            <cDV>5</cDV>
             <tpAmb>2</tpAmb>
             <finNFe>1</finNFe>
             <indFinal>1</indFinal>
@@ -63,17 +63,17 @@
         </dest>
         <det nItem="1">
             <prod>
-                <cProd>22089000</cProd>
+                <cProd>94052000</cProd>
                 <cEAN>SEM GTIN</cEAN>
-                <xProd>[22089000] Finished Product of national origin NCM 22089000</xProd>
-                <NCM>22089000</NCM>
+                <xProd>[94052000] Finished Product of national origin NCM 94052000</xProd>
+                <NCM>94052000</NCM>
                 <CFOP>6101</CFOP>
-                <uCom>LITRO</uCom>
+                <uCom>UNID</uCom>
                 <qCom>2.0000</qCom>
                 <vUnCom>234.0000000000</vUnCom>
                 <vProd>468.00</vProd>
                 <cEANTrib>SEM GTIN</cEANTrib>
-                <uTrib>LITRO</uTrib>
+                <uTrib>UNID</uTrib>
                 <qTrib>2.0000</qTrib>
                 <vUnTrib>234.0000000000</vUnTrib>
                 <indTot>1</indTot>
@@ -85,9 +85,9 @@
                         <orig>0</orig>
                         <CST>00</CST>
                         <modBC>0</modBC>
-                        <vBC>608.40</vBC>
+                        <vBC>538.20</vBC>
                         <pICMS>7.0000</pICMS>
-                        <vICMS>42.59</vICMS>
+                        <vICMS>37.67</vICMS>
                     </ICMS00>
                 </ICMS>
                 <IPI>
@@ -95,8 +95,8 @@
                     <IPITrib>
                         <CST>50</CST>
                         <vBC>468.00</vBC>
-                        <pIPI>30.0000</pIPI>
-                        <vIPI>140.40</vIPI>
+                        <pIPI>15.0000</pIPI>
+                        <vIPI>70.20</vIPI>
                     </IPITrib>
                 </IPI>
                 <PIS>
@@ -116,12 +116,12 @@
                     </COFINSAliq>
                 </COFINS>
             </imposto>
-            <infAdProd>Val Aprox Tributos Federal R$ 140,40</infAdProd>
+            <infAdProd>Val Aprox Tributos Federal R$ 70,20</infAdProd>
         </det>
         <total>
             <ICMSTot>
-                <vBC>608.40</vBC>
-                <vICMS>42.59</vICMS>
+                <vBC>538.20</vBC>
+                <vICMS>37.67</vICMS>
                 <vICMSDeson>0.00</vICMSDeson>
                 <vFCPUFDest>0.00</vFCPUFDest>
                 <vICMSUFDest>0.00</vICMSUFDest>
@@ -136,12 +136,12 @@
                 <vSeg>0.00</vSeg>
                 <vDesc>0.00</vDesc>
                 <vII>0.00</vII>
-                <vIPI>140.40</vIPI>
+                <vIPI>70.20</vIPI>
                 <vIPIDevol>0.00</vIPIDevol>
                 <vPIS>3.04</vPIS>
                 <vCOFINS>14.04</vCOFINS>
                 <vOutro>0.00</vOutro>
-                <vNF>608.40</vNF>
+                <vNF>538.20</vNF>
                 <vTotTrib>0.00</vTotTrib>
             </ICMSTot>
         </total>
@@ -152,7 +152,7 @@
             <detPag>
                 <indPag>0</indPag>
                 <tPag>99</tPag>
-                <vPag>608.40</vPag>
+                <vPag>538.20</vPag>
             </detPag>
             <vTroco>0.00</vTroco>
         </pag>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000041662059365-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000041662059365-nf-e.xml
@@ -6,7 +6,7 @@
             <natOp>Venda</natOp>
             <mod>55</mod>
             <serie>1</serie>
-            <nNF>1</nNF>
+            <nNF>3</nNF>
             <dhEmi>2020-01-01T12:00:00+01:00</dhEmi>
             <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
             <tpNF>1</tpNF>
@@ -14,7 +14,7 @@
             <cMunFG>3550308</cMunFG>
             <tpImp>1</tpImp>
             <tpEmis>1</tpEmis>
-            <cDV>0</cDV>
+            <cDV>6</cDV>
             <tpAmb>2</tpAmb>
             <finNFe>1</finNFe>
             <indFinal>1</indFinal>
@@ -63,17 +63,17 @@
         </dest>
         <det nItem="1">
             <prod>
-                <cProd>94052000</cProd>
+                <cProd>22089000</cProd>
                 <cEAN>SEM GTIN</cEAN>
-                <xProd>[94052000] Finished Product of national origin NCM 94052000</xProd>
-                <NCM>94052000</NCM>
+                <xProd>[22089000] Finished Product of national origin NCM 22089000</xProd>
+                <NCM>22089000</NCM>
                 <CFOP>6101</CFOP>
-                <uCom>UNID</uCom>
+                <uCom>LITRO</uCom>
                 <qCom>2.0000</qCom>
                 <vUnCom>234.0000000000</vUnCom>
                 <vProd>468.00</vProd>
                 <cEANTrib>SEM GTIN</cEANTrib>
-                <uTrib>UNID</uTrib>
+                <uTrib>LITRO</uTrib>
                 <qTrib>2.0000</qTrib>
                 <vUnTrib>234.0000000000</vUnTrib>
                 <indTot>1</indTot>
@@ -85,9 +85,9 @@
                         <orig>0</orig>
                         <CST>00</CST>
                         <modBC>0</modBC>
-                        <vBC>538.20</vBC>
+                        <vBC>608.40</vBC>
                         <pICMS>7.0000</pICMS>
-                        <vICMS>37.67</vICMS>
+                        <vICMS>42.59</vICMS>
                     </ICMS00>
                 </ICMS>
                 <IPI>
@@ -95,8 +95,8 @@
                     <IPITrib>
                         <CST>50</CST>
                         <vBC>468.00</vBC>
-                        <pIPI>15.0000</pIPI>
-                        <vIPI>70.20</vIPI>
+                        <pIPI>30.0000</pIPI>
+                        <vIPI>140.40</vIPI>
                     </IPITrib>
                 </IPI>
                 <PIS>
@@ -116,12 +116,12 @@
                     </COFINSAliq>
                 </COFINS>
             </imposto>
-            <infAdProd>Val Aprox Tributos Federal R$ 70,20</infAdProd>
+            <infAdProd>Val Aprox Tributos Federal R$ 140,40</infAdProd>
         </det>
         <total>
             <ICMSTot>
-                <vBC>538.20</vBC>
-                <vICMS>37.67</vICMS>
+                <vBC>608.40</vBC>
+                <vICMS>42.59</vICMS>
                 <vICMSDeson>0.00</vICMSDeson>
                 <vFCPUFDest>0.00</vFCPUFDest>
                 <vICMSUFDest>0.00</vICMSUFDest>
@@ -136,12 +136,12 @@
                 <vSeg>0.00</vSeg>
                 <vDesc>0.00</vDesc>
                 <vII>0.00</vII>
-                <vIPI>70.20</vIPI>
+                <vIPI>140.40</vIPI>
                 <vIPIDevol>0.00</vIPIDevol>
                 <vPIS>3.04</vPIS>
                 <vCOFINS>14.04</vCOFINS>
                 <vOutro>0.00</vOutro>
-                <vNF>538.20</vNF>
+                <vNF>608.40</vNF>
                 <vTotTrib>0.00</vTotTrib>
             </ICMSTot>
         </total>
@@ -152,7 +152,7 @@
             <detPag>
                 <indPag>0</indPag>
                 <tPag>99</tPag>
-                <vPag>538.20</vPag>
+                <vPag>608.40</vPag>
             </detPag>
             <vTroco>0.00</vTroco>
         </pag>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000041662059365-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000041662059365-nf-e.xml
@@ -117,7 +117,7 @@
                     </COFINSAliq>
                 </COFINS>
             </imposto>
-            <infAdProd>Val Aprox Tributos Federal R$ 70,20</infAdProd>
+            <infAdProd>Val Aprox Tributos Federal R$ 70.20</infAdProd>
         </det>
         <total>
             <ICMSTot>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000041662059365-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000041662059365-nf-e.xml
@@ -14,7 +14,7 @@
             <cMunFG>3550308</cMunFG>
             <tpImp>1</tpImp>
             <tpEmis>1</tpEmis>
-            <cDV>5</cDV>
+            <cDV>1</cDV>
             <tpAmb>2</tpAmb>
             <finNFe>1</finNFe>
             <indFinal>1</indFinal>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000041662059365-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000041662059365-nf-e.xml
@@ -28,6 +28,7 @@
             <xFant>Empresa Lucro Presumido</xFant>
             <enderEmit>
                 <xLgr>Avenida Paulista</xLgr>
+                <nro>1</nro>
                 <xBairro>Bela Vista</xBairro>
                 <cMun>3550308</cMun>
                 <xMun>São Paulo</xMun>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000051678969177-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000051678969177-nf-e.xml
@@ -117,7 +117,7 @@
                     </COFINSAliq>
                 </COFINS>
             </imposto>
-            <infAdProd>Val Aprox Tributos Federal R$ 140,40</infAdProd>
+            <infAdProd>Val Aprox Tributos Federal R$ 140.40</infAdProd>
         </det>
         <total>
             <ICMSTot>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000051678969177-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000051678969177-nf-e.xml
@@ -14,7 +14,7 @@
             <cMunFG>3550308</cMunFG>
             <tpImp>1</tpImp>
             <tpEmis>1</tpEmis>
-            <cDV>7</cDV>
+            <cDV>1</cDV>
             <tpAmb>2</tpAmb>
             <finNFe>1</finNFe>
             <indFinal>1</indFinal>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000051678969177-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000051678969177-nf-e.xml
@@ -1,0 +1,163 @@
+<NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+    <infNFe versao="4.00" Id="NFeTest">
+        <ide>
+            <cUF>35</cUF>
+            <cNF>06277716</cNF>
+            <natOp>Venda</natOp>
+            <mod>55</mod>
+            <serie>1</serie>
+            <nNF>1</nNF>
+            <dhEmi>2020-01-01T12:00:00+01:00</dhEmi>
+            <dhSaiEnt>2020-01-01T12:00:00+01:00</dhSaiEnt>
+            <tpNF>1</tpNF>
+            <idDest>2</idDest>
+            <cMunFG>3550308</cMunFG>
+            <tpImp>1</tpImp>
+            <tpEmis>1</tpEmis>
+            <cDV>7</cDV>
+            <tpAmb>2</tpAmb>
+            <finNFe>1</finNFe>
+            <indFinal>1</indFinal>
+            <indPres>0</indPres>
+            <procEmi>0</procEmi>
+            <verProc>Odoo Brasil v12.0</verProc>
+        </ide>
+        <emit>
+            <CNPJ>81583054000129</CNPJ>
+            <xNome>Empresa Lucro Presumido Ltda</xNome>
+            <xFant>Empresa Lucro Presumido</xFant>
+            <enderEmit>
+                <xLgr>Avenida Paulista</xLgr>
+                <xBairro>Bela Vista</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+                <UF>SP</UF>
+                <CEP>01311000</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>551199999999</fone>
+            </enderEmit>
+            <IE>078016350838</IE>
+            <CRT>3</CRT>
+        </emit>
+        <dest>
+            <CNPJ>84148732000113</CNPJ>
+            <xNome>NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL</xNome>
+            <enderDest>
+                <xLgr>Avenida Javari</xLgr>
+                <nro>s/n</nro>
+                <xCpl>Lote 9.45/15E</xCpl>
+                <xBairro>Distrito Industrial</xBairro>
+                <cMun>1302603</cMun>
+                <xMun>Manaus</xMun>
+                <UF>AM</UF>
+                <CEP>69075110</CEP>
+                <cPais>1058</cPais>
+                <xPais>Brasil</xPais>
+                <fone>9221458888</fone>
+            </enderDest>
+            <indIEDest>1</indIEDest>
+            <IE>095693211</IE>
+            <ISUF>100695108</ISUF>
+            <email>cliente4@cliente4.com.br</email>
+        </dest>
+        <det nItem="1">
+            <prod>
+                <cProd>22089000</cProd>
+                <cEAN>SEM GTIN</cEAN>
+                <xProd>[22089000] Finished Product of national origin NCM 22089000</xProd>
+                <NCM>22089000</NCM>
+                <CFOP>6101</CFOP>
+                <uCom>LITRO</uCom>
+                <qCom>2.0000</qCom>
+                <vUnCom>234.0000000000</vUnCom>
+                <vProd>468.00</vProd>
+                <cEANTrib>SEM GTIN</cEANTrib>
+                <uTrib>LITRO</uTrib>
+                <qTrib>2.0000</qTrib>
+                <vUnTrib>234.0000000000</vUnTrib>
+                <indTot>1</indTot>
+            </prod>
+            <imposto>
+                <vTotTrib>0.00</vTotTrib>
+                <ICMS>
+                    <ICMS00>
+                        <orig>0</orig>
+                        <CST>00</CST>
+                        <modBC>0</modBC>
+                        <vBC>608.40</vBC>
+                        <pICMS>7.0000</pICMS>
+                        <vICMS>42.59</vICMS>
+                    </ICMS00>
+                </ICMS>
+                <IPI>
+                    <cEnq>999</cEnq>
+                    <IPITrib>
+                        <CST>50</CST>
+                        <vBC>468.00</vBC>
+                        <pIPI>30.0000</pIPI>
+                        <vIPI>140.40</vIPI>
+                    </IPITrib>
+                </IPI>
+                <PIS>
+                    <PISAliq>
+                        <CST>01</CST>
+                        <vBC>468.00</vBC>
+                        <pPIS>0.6500</pPIS>
+                        <vPIS>3.04</vPIS>
+                    </PISAliq>
+                </PIS>
+                <COFINS>
+                    <COFINSAliq>
+                        <CST>01</CST>
+                        <vBC>468.00</vBC>
+                        <pCOFINS>3.0000</pCOFINS>
+                        <vCOFINS>14.04</vCOFINS>
+                    </COFINSAliq>
+                </COFINS>
+            </imposto>
+            <infAdProd>Val Aprox Tributos Federal R$ 140,40</infAdProd>
+        </det>
+        <total>
+            <ICMSTot>
+                <vBC>608.40</vBC>
+                <vICMS>42.59</vICMS>
+                <vICMSDeson>0.00</vICMSDeson>
+                <vFCPUFDest>0.00</vFCPUFDest>
+                <vICMSUFDest>0.00</vICMSUFDest>
+                <vICMSUFRemet>0.00</vICMSUFRemet>
+                <vFCP>0.00</vFCP>
+                <vBCST>0.00</vBCST>
+                <vST>0.00</vST>
+                <vFCPST>0.00</vFCPST>
+                <vFCPSTRet>0.00</vFCPSTRet>
+                <vProd>468.00</vProd>
+                <vFrete>0.00</vFrete>
+                <vSeg>0.00</vSeg>
+                <vDesc>0.00</vDesc>
+                <vII>0.00</vII>
+                <vIPI>140.40</vIPI>
+                <vIPIDevol>0.00</vIPIDevol>
+                <vPIS>3.04</vPIS>
+                <vCOFINS>14.04</vCOFINS>
+                <vOutro>0.00</vOutro>
+                <vNF>608.40</vNF>
+                <vTotTrib>0.00</vTotTrib>
+            </ICMSTot>
+        </total>
+        <transp>
+            <modFrete>9</modFrete>
+        </transp>
+        <pag>
+            <detPag>
+                <indPag>0</indPag>
+                <tPag>99</tPag>
+                <vPag>608.40</vPag>
+            </detPag>
+            <vTroco>0.00</vTroco>
+        </pag>
+        <infAdic>
+            <infAdFisco>Documento emitido por: Marc Demo</infAdFisco>
+        </infAdic>
+    </infNFe>
+</NFe>

--- a/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000051678969177-nf-e.xml
+++ b/l10n_br_nfe/tests/nfe/v4_00/leiauteNFe/NFe35210381583054000129550010000000051678969177-nf-e.xml
@@ -28,6 +28,7 @@
             <xFant>Empresa Lucro Presumido</xFant>
             <enderEmit>
                 <xLgr>Avenida Paulista</xLgr>
+                <nro>1</nro>
                 <xBairro>Bela Vista</xBairro>
                 <cMun>3550308</cMun>
                 <xMun>São Paulo</xMun>

--- a/l10n_br_nfe/tests/test_nfe_serialize.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize.py
@@ -2,16 +2,19 @@
 #   Gabriel Cardoso de Faria <gabriel.cardoso@kmee.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from datetime import datetime
+from OpenSSL import crypto
+from base64 import b64encode
+from datetime import timedelta, datetime
 from xmldiff import main
 
+from odoo import fields
+from odoo.tools.misc import format_date
 from odoo.tools import config
 import os
 import logging
 
 from odoo.tests.common import TransactionCase
 from odoo.addons import l10n_br_nfe
-from odoo.addons.l10n_br_fiscal.constants.fiscal import PROCESSADOR_OCA
 from odoo.addons.spec_driven_model import hooks
 
 _logger = logging.getLogger(__name__)
@@ -22,40 +25,108 @@ class TestNFeExport(TransactionCase):
         super(TestNFeExport, self).setUp()
         hooks.register_hook(self.env, 'l10n_br_nfe',
                             'odoo.addons.l10n_br_nfe_spec.models.v4_00.leiauteNFe')
-        self.nfe = self.env.ref('l10n_br_nfe.demo_nfe_same_state')
-        self.nfe.write(
-            {'document_type_id': self.env.ref('l10n_br_fiscal.document_55').id,
-             'company_id': self.env.ref('l10n_br_base.empresa_lucro_presumido').id,
-             'company_number': 3,
-             'processador_edoc': PROCESSADOR_OCA,
-             })
-        self.nfe.company_id.processador_edoc = PROCESSADOR_OCA
-        if self.nfe.state != 'em_digitacao':  # 2nd test run
-            self.nfe.action_document_back2draft()
+        self.nfe_list = []
 
-        for line in self.nfe.line_ids:
+        self.cert_country = "BR"
+        self.cert_issuer_a = "EMISSOR A TESTE"
+        self.cert_issuer_b = "EMISSOR B TESTE"
+        self.cert_subject_valid = "CERTIFICADO VALIDO TESTE"
+        self.cert_date_exp = fields.Datetime.today() + timedelta(days=365)
+        self.cert_subject_invalid = "CERTIFICADO INVALIDO TESTE"
+        self.cert_passwd = "123456"
+        self.cert_name = "{} - {} - {} - Valid: {}".format(
+            "NF-E",
+            "A1",
+            self.cert_subject_valid,
+            format_date(self.env, self.cert_date_exp),
+        )
+        self.certificate_model = self.env["l10n_br_fiscal.certificate"]
+
+        self.certificate_valid = self._create_certificate(
+            valid=True, passwd=self.cert_passwd, issuer=self.cert_issuer_a,
+            country=self.cert_country, subject=self.cert_subject_valid)
+
+        self.cert = self.certificate_model.create(
+            {
+                'type': 'nf-e',
+                'subtype': 'a1',
+                'password': self.cert_passwd,
+                'file': self.certificate_valid
+            }
+        )
+
+    def _create_certificate(self, valid=True, passwd=None, issuer=None,
+                            country=None, subject=None):
+        """Creating a fake certificate"""
+
+        key = crypto.PKey()
+        key.generate_key(crypto.TYPE_RSA, 2048)
+
+        cert = crypto.X509()
+
+        cert.get_issuer().C = country
+        cert.get_issuer().CN = issuer
+
+        cert.get_subject().C = country
+        cert.get_subject().CN = subject
+
+        cert.set_serial_number(2009)
+
+        if valid:
+            time_before = 0
+            time_after = 365 * 24 * 60 * 60
+        else:
+            time_before = -1 * (365 * 24 * 60 * 60)
+            time_after = 0
+
+        cert.gmtime_adj_notBefore(time_before)
+        cert.gmtime_adj_notAfter(time_after)
+        cert.set_pubkey(key)
+        cert.sign(key, 'md5')
+
+        p12 = crypto.PKCS12()
+        p12.set_privatekey(key)
+        p12.set_certificate(cert)
+
+        return b64encode(p12.export(passwd))
+
+    def prepare_test_nfe(self, nfe):
+        """
+        Performs actions necessary to prepare an NFe of the demo data to
+        perform the tests
+        """
+        if nfe.state != 'em_digitacao':  # 2nd test run
+            nfe.action_document_back2draft()
+
+        for line in nfe.line_ids:
             line._onchange_product_id_fiscal()
             line._onchange_fiscal_operation_id()
             line._onchange_fiscal_operation_line_id()
 
-        self.nfe.company_id.street_number = '3'
-
     def test_serialize_xml(self):
-        xml_path = os.path.join(
-            l10n_br_nfe.__path__[0], 'tests', 'nfe', 'v4_00', 'leiauteNFe',
-            'NFe35200697231608000169550010000000111855451724-nf-e.xml')
-        self.nfe.action_document_confirm()
-        self.nfe.date = datetime.strptime(
-            '2020-06-04T11:58:46', '%Y-%m-%dT%H:%M:%S')
-        self.nfe.date_in_out = datetime.strptime(
-            '2020-06-04T11:58:46', '%Y-%m-%dT%H:%M:%S')
-        self.nfe.nfe40_cNF = '06277716'
-        self.nfe.nfe40_Id = 'NFe35200781583054000129550010000000011062777160'
-        self.nfe.with_context(lang='pt_BR')._document_export()
-        output = os.path.join(config['data_dir'], 'filestore',
-                              self.cr.dbname, self.nfe.file_xml_id.store_fname)
-        _logger.info("XML file saved at %s" % (output,))
-        self.nfe.company_id.country_id.name = 'Brazil'  # clean mess
-        diff = main.diff_files(xml_path, output)
-        _logger.info("Diff with expected XML (if any): %s" % (diff,))
-        assert len(diff) == 0
+
+        for nfe in self.nfe_list:
+            nfe_id = nfe['record_id']
+
+            self.prepare_test_nfe(nfe_id)
+
+            xml_path = os.path.join(
+                l10n_br_nfe.__path__[0], 'tests', 'nfe', 'v4_00', 'leiauteNFe',
+                nfe['xml_file'])
+            nfe_id.action_document_confirm()
+            nfe_id.date = datetime.strptime(
+                '2020-01-01T11:00:00', '%Y-%m-%dT%H:%M:%S')
+            nfe_id.date_in_out = datetime.strptime(
+                '2020-01-01T11:00:00', '%Y-%m-%dT%H:%M:%S')
+            nfe_id.nfe40_cNF = '06277716'
+            nfe_id.nfe40_Id = 'NFeTest'
+            nfe_id.nfe40_nNF = '1'
+            nfe_id.nfe40_cDV = '1'
+            nfe_id.with_context(lang='pt_BR')._document_export()
+            output = os.path.join(config['data_dir'], 'filestore',
+                                  self.cr.dbname,  nfe_id.file_xml_id.store_fname)
+            _logger.info("XML file saved at %s" % (output,))
+            nfe_id.company_id.country_id.name = 'Brazil'  # clean mess
+            diff = main.diff_files(xml_path, output)
+            _logger.info("Diff with expected XML (if any): %s" % (diff,))
+            assert len(diff) == 0

--- a/l10n_br_nfe/tests/test_nfe_serialize_lc.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize_lc.py
@@ -1,0 +1,40 @@
+# @ 2020 KMEE INFORMATICA LTDA - www.kmee.com.br -
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import os
+from .test_nfe_serialize import TestNFeExport
+
+class TestNFeExportLC(TestNFeExport):
+    def setUp(self):
+        super().setUp()
+
+        company_id = self.env.ref('l10n_br_base.empresa_lucro_presumido')
+        company_id.certificate_nfe_id = self.cert
+
+        self.nfe_list = [
+            {
+                'record_id':
+                    self.env.ref(
+                        'l10n_br_nfe.demo_nfe_same_state'),
+                'xml_file':
+                    'NFe35200697231608000169550010000000111855451724-nf-e.xml',
+            },
+            {
+                'record_id':
+                    self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11'),
+                'xml_file':
+                    'NFe35210381583054000129550010000000011659437930-nf-e.xml',
+            },
+            {
+                'record_id':
+                    self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15'),
+                'xml_file':
+                    'NFe35210381583054000129550010000000031659634756-nf-e.xml',
+            },
+            {
+                'record_id':
+                    self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale'),
+                'xml_file':
+                    'NFe35210381583054000129550010000000011659437930-nf-e.xml',
+            },
+
+        ]

--- a/l10n_br_nfe/tests/test_nfe_serialize_lc.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize_lc.py
@@ -26,8 +26,9 @@ class TestNFeExportLC(TestNFeExport):
                     'NFe35210381583054000129550010000000021659443040-nf-e.xml',
             },
             {
-                'record_id':
-                    self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15_sp_am'),
+                'record_id': self.env.ref(
+                    'l10n_br_nfe.demo_nfe_natural_icms_18_resale'
+                ),
                 'xml_file':
                     'NFe35210381583054000129550010000000031659634756-nf-e.xml',
             },

--- a/l10n_br_nfe/tests/test_nfe_serialize_lc.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize_lc.py
@@ -19,8 +19,9 @@ class TestNFeExportLC(TestNFeExport):
                     'NFe35200697231608000169550010000000111855451724-nf-e.xml',
             },
             {
-                'record_id':
-                    self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11'),
+                'record_id': self.env.ref(
+                        'l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11'
+                ),
                 'xml_file':
                     'NFe35210381583054000129550010000000021659443040-nf-e.xml',
             },

--- a/l10n_br_nfe/tests/test_nfe_serialize_lc.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize_lc.py
@@ -22,11 +22,11 @@ class TestNFeExportLC(TestNFeExport):
                 'record_id':
                     self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11'),
                 'xml_file':
-                    'NFe35210381583054000129550010000000011659437930-nf-e.xml',
+                    'NFe35210381583054000129550010000000021659443040-nf-e.xml',
             },
             {
                 'record_id':
-                    self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15'),
+                    self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15_sp_am'),
                 'xml_file':
                     'NFe35210381583054000129550010000000031659634756-nf-e.xml',
             },
@@ -35,6 +35,12 @@ class TestNFeExportLC(TestNFeExport):
                     self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale'),
                 'xml_file':
                     'NFe35210381583054000129550010000000011659437930-nf-e.xml',
+            },
+            {
+                'record_id':
+                    self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale'),
+                'xml_file':
+                    'NFe35210381583054000129550010000000041662059365-nf-e.xml',
             },
 
         ]

--- a/l10n_br_nfe/tests/test_nfe_serialize_lc.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize_lc.py
@@ -47,10 +47,10 @@ class TestNFeExportLC(TestNFeExport):
                     'NFe35210381583054000129550010000000011659437930-nf-e.xml',
             },
             {
-                'record_id':
-                    self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale'),
+                'record_id': self.env.ref(
+                    'l10n_br_nfe.demo_nfe_natural_icms_7_sp_am'
+                ),
                 'xml_file':
-                    'NFe35210381583054000129550010000000041662059365-nf-e.xml',
+                    'NFe35210381583054000129550010000000051678969177-nf-e.xml',
             },
-
         ]

--- a/l10n_br_nfe/tests/test_nfe_serialize_lc.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize_lc.py
@@ -1,7 +1,7 @@
 # @ 2020 KMEE INFORMATICA LTDA - www.kmee.com.br -
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-import os
 from .test_nfe_serialize import TestNFeExport
+
 
 class TestNFeExportLC(TestNFeExport):
     def setUp(self):
@@ -20,7 +20,7 @@ class TestNFeExportLC(TestNFeExport):
             },
             {
                 'record_id': self.env.ref(
-                        'l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11'
+                    'l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11'
                 ),
                 'xml_file':
                     'NFe35210381583054000129550010000000021659443040-nf-e.xml',

--- a/l10n_br_nfe/tests/test_nfe_serialize_lc.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize_lc.py
@@ -33,8 +33,16 @@ class TestNFeExportLC(TestNFeExport):
                     'NFe35210381583054000129550010000000031659634756-nf-e.xml',
             },
             {
-                'record_id':
-                    self.env.ref('l10n_br_nfe.demo_nfe_natural_icms_18_resale'),
+                'record_id': self.env.ref(
+                    'l10n_br_nfe.demo_nfe_natural_icms_7_IPI_15_sp_am'
+                ),
+                'xml_file':
+                    'NFe35210381583054000129550010000000041662059365-nf-e.xml',
+            },
+            {
+                'record_id': self.env.ref(
+                    'l10n_br_nfe.demo_nfe_natural_icms_7_resale'
+                ),
                 'xml_file':
                     'NFe35210381583054000129550010000000011659437930-nf-e.xml',
             },

--- a/l10n_br_nfe/tests/test_nfe_serialize_sn.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize_sn.py
@@ -3,7 +3,7 @@
 from .test_nfe_serialize import TestNFeExport
 
 
-class TestNFeExportLC(TestNFeExport):
+class TestNFeExportSN(TestNFeExport):
     def setUp(self):
         super().setUp()
 

--- a/l10n_br_nfe/tests/test_nfe_serialize_sn.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize_sn.py
@@ -11,11 +11,11 @@ class TestNFeExportLC(TestNFeExport):
         company_id.certificate_nfe_id = self.cert
 
         self.nfe_list = [
-            # {
-            #     'record_id':
-            #         self.env.ref(
-            #             'l10n_br_nfe.demo_nfe_national_sale_for_same_state'),
-            #     'xml_file':
-            #         'NFe35210359594315000157550010000000011291881715-nf-e.xml',
-            # },
+            {
+                'record_id':
+                    self.env.ref(
+                        'l10n_br_nfe.demo_nfe_national_sale_for_same_state'),
+                'xml_file':
+                    'NFe35210359594315000157550010000000011291881715-nf-e.xml',
+            },
         ]

--- a/l10n_br_nfe/tests/test_nfe_serialize_sn.py
+++ b/l10n_br_nfe/tests/test_nfe_serialize_sn.py
@@ -1,0 +1,21 @@
+# @ 2020 KMEE INFORMATICA LTDA - www.kmee.com.br -
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from .test_nfe_serialize import TestNFeExport
+
+
+class TestNFeExportLC(TestNFeExport):
+    def setUp(self):
+        super().setUp()
+
+        company_id = self.env.ref('l10n_br_base.empresa_simples_nacional')
+        company_id.certificate_nfe_id = self.cert
+
+        self.nfe_list = [
+            # {
+            #     'record_id':
+            #         self.env.ref(
+            #             'l10n_br_nfe.demo_nfe_national_sale_for_same_state'),
+            #     'xml_file':
+            #         'NFe35210359594315000157550010000000011291881715-nf-e.xml',
+            # },
+        ]


### PR DESCRIPTION
Olá pessoal,
Esse PR adiciona duas coisa principais: 
- Adição de mais demonstrações de NFe, cobrindo diferente casos.
- Refatoração do framework de testes de serialização de NFe.

Casos cobertos nos dados de demonstração:
- Vendas por Empresa do Lucro Presumido
  - Venda de produto com redução de ICMS para pessoa física do mesmo estado
  - Revenda de produto para pessoa física do mesmo estado
  - Venda para pessoa física de outro estado
  - Revenda para empresa do Simples Nacional de outro estado
  - Venda para empresa do Simples Nacional de outro estado
- Vendas por Empresa do Simples Nacional
  - Venda para empresa do Simples Nacional do mesmo estado 

Depende dos PRs:
- Dados de demonstração de parceiro não contribuinte de São Paulo (https://github.com/OCA/l10n-brazil/pull/1239)
- Dados de demonstração de produtos e parametrização (https://github.com/OCA/l10n-brazil/pull/1240)
- Correção do cálculo do crédito de ICMS (https://github.com/OCA/l10n-brazil/pull/1238)
