### PR TITLE
[FIX] Add company in search account.tax

### DIFF
--- a/l10n_br_account/models/fiscal_tax.py
+++ b/l10n_br_account/models/fiscal_tax.py
@@ -22,7 +22,11 @@ class FiscalTax(models.Model):
         self.ensure_one()
         account_tax_group = self.tax_group_id.account_tax_group()
         return self.env["account.tax"].search(
-            [("tax_group_id", "=", account_tax_group.id), ("active", "=", True)]
+            [
+                ("tax_group_id", "=", account_tax_group.id),
+                ("active", "=", True),
+                ("company_id", "=", self.env.company.id),
+            ]
         )
 
     def _create_account_tax(self):


### PR DESCRIPTION
Supondo que o usuário esteja visualizando os dados de mais de uma empresa, ao criar uma linha da fatura são adicionado todos os impostos vinculados a todas as empresas sendo visualizadas. Na imagem a seguir é possivel ver todos os impostos vinculados e o erro que estoura ao salvar a fatura.

![tax_all_companies](https://user-images.githubusercontent.com/6812128/158229329-ae657173-828e-472a-9f06-127527fdc397.png)

