### PR TITLE
Validação schema NF-e - Refactor XSDATA (2)

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -4,12 +4,16 @@
 
 import base64
 import logging
+import os
 import re
 import string
+import xml.etree.ElementTree as ET
 from datetime import datetime
-from io import StringIO
+from pathlib import Path
 from unicodedata import normalize
 
+import nfelib
+import xmlschema
 from erpbrasil.assinatura import certificado as cert
 from erpbrasil.base.fiscal.edoc import ChaveEdoc
 from erpbrasil.edoc.nfe import NFe as edoc_nfe
@@ -671,7 +675,7 @@ class NFe(spec_models.StackedModel):
             record.authorization_event_id = event_id
             # TODO copy decent assina_raiz method here
             xml_assinado = "TODO"  # processador.assina_raiz(edoc, edoc.InfNfe.id)
-            self._valida_xml(xml_assinado)
+            self._valida_xml(xml_file)
 
     def _render_edoc(self, edoc_binding, pretty_print=True):
         "used to be in erpbrasil.edoc, but hacked here for xsdata"
@@ -721,11 +725,17 @@ class NFe(spec_models.StackedModel):
         self._change_state(state)
 
     def _valida_xml(self, xml_file):
-        return True  # FIXME adapt for xsdata
         self.ensure_one()
-        erros = nfe_sub.schema_validation(StringIO(xml_file))
-        erros = "\n".join(erros)
-        self.write({"xml_error_message": erros or False})
+        path = os.path.dirname(nfelib.__file__)
+        module_path = str(Path(path).parents[0])
+        schema_path = os.path.join(module_path, "schemas/nfe/v4_0/nfe_v4.00.xsd")
+        xml_tree = ET.ElementTree(ET.fromstring(xml_file))
+        iter_errors = xmlschema.iter_errors(xml_document=xml_tree, schema=schema_path)
+        errors = ""
+        for error in iter_errors:
+            errors += "(" + re.sub("{.*?}", "", error.path) + ") "
+            errors += error.reason + "\n"
+        self.write({"xml_error_message": errors or False})
 
     def _eletronic_document_send(self):
         super(NFe, self)._eletronic_document_send()


### PR DESCRIPTION
Para validação do XML com o schema XSD antes era utilizado o próprio GenereteDS, porém o XSDATA não tem a funcionalidade de validar o XML com o schema, o recomendado é utilizar uma biblioteca especifica para esse fim.

Optei utilizar o [xmlschema](https://xmlschema.readthedocs.io/en/latest/index.html) conforme sugerido na documentação do XSDATA.

@rvalyi será que é tudo bem eu fazer todo o tratamento dentro do próprio l10n_br_nfe ? penso que dessa forma temos mais liberdade de tratar os erros com mais detalhamento e tals.. 

Por enquanto fiz uma representação bem simples dos erros, mas no futuro dá pra melhorar, deixar as mensagens mais claras para o usuário final.

Outra coisa que vi legal no lib xmlschema é que foi incluído recentemente suporte para localizações, dá pra gerar um arquivo .pot com as traduções em PT-Br.

Exemplo de como fica os erros com esta PR:
![image](https://user-images.githubusercontent.com/634278/173943047-887f66eb-b679-486c-90ca-a8fa3f725e09.png)

o bom de já ter essa validação , mesmo que simples, é que agiliza fazer os testes e encontrar os erros 👍🏻 


