### PR TITLE
[14.0][FIX] spec_driven_model - comodel_name

### DIFF
--- a/spec_driven_model/models/spec_export.py
+++ b/spec_driven_model/models/spec_export.py
@@ -139,9 +139,12 @@ class AbstractSpecMixin(models.AbstractModel):
                 class_name=self._stacking_points[field_name].comodel_name
             )
         else:
-            return (self[field_name] or self)._build_generateds(
-                class_obj._fields[field_name].comodel_name
-            )
+            _field = class_obj._fields[field_name]
+            if hasattr(_field, "original_comodel_name"):
+                comodel_name = _field.original_comodel_name
+            else:
+                comodel_name = _field.comodel_name
+            return (self[field_name] or self)._build_generateds(comodel_name)
 
     def _export_one2many(self, field_name, class_obj=None):
         self.ensure_one()


### PR DESCRIPTION
fix para pegar o nome correto do comodel_name, sem essa correção o spec_driven_model fica confuso e se perde no mapeamento, podendo acontecer erros aleatórios .

com o módulo  **l10n_br_account** instalado eu frenquentemente recebia esse erro :

```
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 639, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 315, in _handle_exception
    raise exception.with_traceback(None) from new_cause
xsdata.exceptions.SerializerError: Tendereco is not derived from TenderEmi
```


