### PR TITLE
14.0 edi fixes

### DIFF
--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -10,7 +10,7 @@
     "maintainers": ["renatonlima"],
     "website": "https://github.com/OCA/l10n-brazil",
     "development_status": "Production/Stable",
-    "version": "14.0.22.4.2",
+    "version": "14.0.23.0.0",
     "depends": [
         "product",
         "l10n_br_base",

--- a/l10n_br_fiscal/migrations/14.0.23.0.0/pre-migration.py
+++ b/l10n_br_fiscal/migrations/14.0.23.0.0/pre-migration.py
@@ -20,3 +20,8 @@ def install_new_modules(cr):
 @openupgrade.migrate()
 def migrate(env, version):
     install_new_modules(env.cr)
+    query = """
+        DELETE FROM ir_model_fields
+            WHERE model = 'l10n_br_fiscal.document.electronic'
+    """
+    openupgrade.logged_query(env.cr, query)

--- a/l10n_br_fiscal_edi/views/document_view.xml
+++ b/l10n_br_fiscal_edi/views/document_view.xml
@@ -7,9 +7,6 @@
       <field name="priority">5</field>
       <field name="inherit_id" ref="l10n_br_fiscal.document_form" />
       <field name="arch" type="xml">
-        <xpath expr="//field[@name='state_edoc']/.." position="after">
-            : <field name="status_description" />
-        </xpath>
         <xpath expr="//page[@name='delivery']" position="after">
             <page name="others" string="EDI">
                 <group>


### PR DESCRIPTION
Ao tentar atualizar uma cópia da base de produção estava dando erro:

```
2024-08-31 23:05:41,331 1 INFO devel odoo.addons.base.models.ir_model: Deleting 1609@ir.model.fields.selection (l10n_br_fiscal.selection__l10n_br_fiscal_document_electronic__state_fiscal__mr) 
2024-08-31 23:05:41,337 1 WARNING devel odoo.modules.loading: Transient module states were reset 
2024-08-31 23:05:41,337 1 ERROR devel odoo.modules.registry: Failed to load registry 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 505, in load_modules
    env['ir.model.data']._process_end(processed_modules)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 2328, in _process_end
    self._process_end_unlink_record(record)
  File "/opt/odoo/auto/addons/website/models/ir_model_data.py", line 36, in _process_end_unlink_record
    return super()._process_end_unlink_record(record)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 2251, in _process_end_unlink_record
    record.unlink()
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 1390, in unlink
    self._process_ondelete()
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_model.py", line 1428, in _process_ondelete
    Model = self.env[selection.field_id.model]
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 489, in getitem
    return self.registry[model_name]._browse(self, (), ())
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 177, in getitem
    return self.models[model_name]
KeyError: 'l10n_br_fiscal.document.electronic'
```

Por algum motivo o odoo não tava conseguiindo lidar bem com essa cara:

![raname field](https://github.com/user-attachments/assets/4f27e188-0498-4c0d-84f6-ae9721748538)

Para resolver isso, adicionei no script de migração uma instrução para forçar apagar esse ir.model.fields diretamente no banco de dados.

Já aproveitei e apaguei o campo `status_description` que tava aparecendo na visão fora do lugar.

Testei com uma cópia da produção e tá tudo funcionando bem, emissão, carta de correção, cancelamento e inutilização. Os dados antigos estão sendo exibidos corretamente. 

