### PR TITLE
[IMP] l10n_br_account: fiscal proxy product_id

### DIFF
--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -58,8 +58,7 @@ class AccountMoveLine(models.Model):
     @api.onchange("product_id")
     def _inverse_product_id(self):
         for line in self:
-            if line.fiscal_document_line_id:
-                line.fiscal_document_line_id.product_id = line.product_id.id
+            line.proxy_product_id = line.product_id.id
         return super()._inverse_product_id()
 
     @api.onchange("name")

--- a/l10n_br_account/models/document_line.py
+++ b/l10n_br_account/models/document_line.py
@@ -27,7 +27,22 @@ class FiscalDocumentLine(models.Model):
     # SHADOWED FIELDS SYNC
     # -------------------------------------------------------------------------
 
-    product_id = fields.Many2one(inverse="_inverse_product_id")
+    proxy_product_id = fields.Many2one(
+        comodel_name="product.product",
+        string="Product (proxy)",
+        help="Technical Field.",
+        readonly=False,
+    )
+
+    product_id = fields.Many2one(
+        related="proxy_product_id",
+        comodel_name="product.product",
+        string="Product",
+        store=True,
+        precompute=True,
+        readonly=False,
+    )
+
     name = fields.Char(inverse="_inverse_name")
     quantity = fields.Float(inverse="_inverse_quantity")
     price_unit = fields.Float(inverse="_inverse_price_unit")

--- a/l10n_br_account/views/account_move_view.xml
+++ b/l10n_br_account/views/account_move_view.xml
@@ -154,6 +154,7 @@
                     domain here that is checked before the dynamic fiscal
                     placeholders kick in.
                 -->
+                <field name="proxy_product_id" invisible="1" />
                 <field name="fiscal_operation_id" invisible="1" />
                 <field name="document_type_id" invisible="1" />
                 <field name="fiscal_operation_type" invisible="1" />
@@ -288,6 +289,7 @@
                     name="fiscal_price"
                     attrs="{'invisible': [('document_type_id', '=', False)]}"
                 />
+                <field name="proxy_product_id" invisible="1" />
                 <field name="amount_currency" invisible="1" />
                 <field name="date" invisible="1" />
                 <field name="date_maturity" invisible="1" />


### PR DESCRIPTION
@rvalyi 

Trouxe a implementação do proxy de forma minimalista para você avaliar, eu ainda acho que essa pode ser a melhor solução, veja que o inverse ainda é utilizado, mas usando o proxy como intermediario. Essa é uma forma de contornar a limitação da ORM, onde os campos de mesmo nomes são ignorados.

O campo proxy é adicionado na view como invisible para que a informação não se perca entre as requisições
