### PR TITLE
[16.0] Fix draft/reset and payment-mode validation regressions

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -484,6 +484,7 @@ class AccountMove(models.Model):
                 move.state_edoc == DOCUMENT_STATE_CANCEL
                 and move.document_number
                 and move.issuer == DOCUMENT_ISSUER_COMPANY
+                and move.fiscal_document_id.cancel_event_id
             ):
                 raise UserError(
                     _(

--- a/l10n_br_account_nfe/models/document.py
+++ b/l10n_br_account_nfe/models/document.py
@@ -152,7 +152,7 @@ class DocumentNfe(models.Model):
     def _check_fiscal_payment_mode(self):
         for rec in self:
             if (
-                rec.state_edoc == "em_digitacao"
+                rec.state_edoc in ("em_digitacao", "draft")
                 or not rec._need_compute_nfe_tags()
                 or rec._is_without_payment()
             ):


### PR DESCRIPTION
### Motivation
- Fix two regressions introduced by the fiscal state/payment-mode refactor that caused `TestMoveEdition.test_out_fiscal_invoice` and `TestGeneratePaymentInfo.test_payment_mode_without_fiscal_mode` to fail by making draft/reset and payment-mode validation behave correctly in the expected lifecycle.

### Description
- Add a stricter guard in `account.move.button_draft()` so it only prevents returning to draft when the related fiscal document has an actual SEFAZ cancel event (`fiscal_document_id.cancel_event_id`), and update the NF-e constraint `_check_fiscal_payment_mode` to skip validation when `state_edoc` is either `"em_digitacao"` or `"draft"`; files changed: `l10n_br_account/models/account_move.py`, `l10n_br_account_nfe/models/document.py`.

### Testing
- Ran `python -m compileall -q l10n_br_account/models/account_move.py l10n_br_account_nfe/models/document.py` which succeeded. 
- Attempted targeted pytest for `l10n_br_account/tests/test_move_edition.py -k test_out_fiscal_invoice` but the local environment lacks the `odoo` Python module so the test run could not be executed here; CI should validate the changes against the full OCA/16.0 test matrix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e436843083319626b2a5ad3d3c2b)