### PR TITLE
[IMP] l10n_br_fiscal_edi: align FSM docs with implementation

### DIFF
--- a/l10n_br_fiscal_edi/readme/DESCRIPTION.md
+++ b/l10n_br_fiscal_edi/readme/DESCRIPTION.md
@@ -1,19 +1,36 @@
-Este módulo fornece a infraestrutura base para o Intercâmbio Eletrônico de Dados (EDI) de documentos fiscais brasileiros no Odoo.
+Este módulo fornece a infraestrutura base para o Intercâmbio Eletrônico de Dados (EDI)
+de documentos fiscais brasileiros no Odoo.
 
-Ele implementa uma Máquina de Estados Finitos (FSM - Finite State Machine) robusta para gerenciar o ciclo de vida dos documentos fiscais eletrônicos (NF-e, NFS-e, CT-e, MDF-e, etc.), garantindo integridade, consistência e rastreabilidade em todas as transições de estado.
+Ele implementa uma Máquina de Estados Finitos (FSM - Finite State Machine)
+para gerenciar o ciclo de vida dos documentos fiscais eletrônicos
+(NF-e, NFC-e, NFS-e, CT-e, MDF-e etc.), garantindo integridade,
+consistência e rastreabilidade das transições de estado.
 
 Principais Características
-------------------------
+--------------------------
 
-*   **Máquina de Estados (FSM):** Controle rigoroso das transições de estado (ex: de 'Em Aberto' para 'Enviando', e subsequentemente para 'Autorizado', 'Rejeitado' ou 'Denegado'), prevenindo movimentos inválidos e garantindo que o documento reflita a realidade fiscal.
-*   **Gerenciamento de Eventos:** Arquitetura para suportar eventos fiscais vinculados ao documento, como Cancelamento, Carta de Correção Eletrônica (CC-e) e Inutilização de Numeração.
-*   **Abstração de Protocolo:** Separa a lógica de negócios da lógica de comunicação. Módulos específicos (como `l10n_br_nfe` ou `l10n_br_nfse`) herdam deste módulo para implementar a comunicação com os webservices (SEFAZ/Prefeituras), enquanto o `l10n_br_fiscal_edi` orquestra o fluxo.
-*   **Interface Padronizada:** Oferece uma experiência de usuário consistente com botões e ações uniformes, independentemente do modelo de documento fiscal (55, 65, 57, etc.).
+* **Máquina de Estados (FSM):** controle rigoroso das transições de estado
+  (por exemplo, de `draft` para `open`, depois para `sending` e finalmente
+  para `authorized`, `rejected` ou `denied`), com bloqueio de movimentos
+  inválidos.
+* **Configuração extensível por documento:** a FSM base é definida no método
+  `get_state_machine_config()` e pode ser sobrescrita por módulos específicos
+  de documento fiscal para ajustar estados, transições e callbacks.
+* **Gerenciamento de Eventos:** arquitetura para suportar eventos fiscais
+  vinculados ao documento, como Cancelamento, Carta de Correção Eletrônica
+  (CC-e) e Inutilização de Numeração.
+* **Abstração de Protocolo:** separa a lógica de negócios da lógica de
+  comunicação. Módulos específicos (como `l10n_br_nfe` ou `l10n_br_nfse`)
+  herdam deste módulo para implementar a integração com webservices
+  (SEFAZ/Prefeituras), enquanto o `l10n_br_fiscal_edi` orquestra o fluxo.
+* **Interface Padronizada:** oferece uma experiência consistente com botões e
+  ações uniformes, independentemente do modelo de documento fiscal.
 
 Workflow de Estados
 -------------------
 
-O diagrama abaixo ilustra os possíveis estados e transições gerenciados pelo módulo:
+O diagrama abaixo ilustra os estados e transições padrão definidos no módulo
+base (a configuração pode ser estendida/sobrescrita por módulos filhos):
 
 .. image:: ../static/description/fsm_graph.png
    :alt: Diagrama da Máquina de Estados (FSM)

--- a/l10n_br_fiscal_edi/readme/USAGE.md
+++ b/l10n_br_fiscal_edi/readme/USAGE.md
@@ -1,32 +1,69 @@
-O fluxo de trabalho operacional para emissão e gerenciamento de documentos fiscais eletrônicos segue as etapas abaixo:
+O fluxo operacional para emissão e gerenciamento de documentos fiscais
+(eletrônicos e não eletrônicos) segue as etapas abaixo.
 
-1. Validação (Rascunho -> Em Aberto)
-------------------------------------
-*   O documento inicia no estado **Rascunho** (`Draft`).
-*   Ao clicar no botão **Confirmar**, o sistema executa validações de integridade (campos obrigatórios, regras de negócio básicas) e atribui a numeração sequencial (se configurado).
-*   O estado muda para **Em Aberto** (`Open`), indicando que o documento está pronto para transmissão.
+1. Validação (`draft` -> `open`)
+--------------------------------
 
-2. Transmissão (Em Aberto -> Enviando -> Resultado)
----------------------------------------------------
-*   No estado **Em Aberto**, o botão **Enviar** fica disponível.
-*   Ao acionar o envio, o documento passa para o estado transitório **Enviando** (`Sending`). Neste momento, o sistema se comunica com o webservice do fisco.
-*   **Autorização:** Se o fisco validar e autorizar o documento, o estado muda para **Autorizado** (`Authorized`). O protocolo de autorização e o XML final são gravados.
-*   **Rejeição:** Se houver erros de validação no fisco, o estado muda para **Rejeitado** (`Rejected`). As mensagens de erro retornadas pela SEFAZ são exibidas no painel do documento.
-    *   *Ação:* O usuário pode corrigir os dados no próprio documento e clicar em **Enviar** novamente para tentar uma nova transmissão.
-*   **Denegação:** Se houver irregularidade fiscal (emitente ou destinatário), o estado muda para **Denegado** (`Denied`). Este é um estado final; o número não pode ser reutilizado ou corrigido.
+* O documento inicia no estado **Rascunho** (`draft`).
+* Ao clicar no botão **Confirmar**, o sistema executa validações de
+  integridade, define data, comentário, numeração/sequência (quando aplicável)
+  e demais preparações do documento.
+* O estado muda para **Em Aberto** (`open`), indicando que o documento está
+  apto para o próximo passo.
 
-3. Cancelamento
----------------
-*   Documentos **Autorizados** podem ser cancelados, desde que dentro do prazo legal e atendendo às regras da UF.
-*   Clique no botão **Cancelar** para abrir o assistente. É obrigatório informar uma justificativa (mínimo de 15 caracteres).
-*   Após o processamento do evento de cancelamento, o estado do documento muda para **Cancelado** (`Cancelled`).
-*   *Nota:* Documentos em Rascunho ou Em Aberto (não transmitidos) podem ser cancelados localmente sem comunicação com o fisco.
+2. Transmissão (`open` -> `sending` -> resultado)
+-------------------------------------------------
 
-4. Eventos e Correções
+* No estado **Em Aberto**, o botão **Enviar** fica disponível.
+* Ao enviar, o documento vai para o estado transitório **Enviando**
+  (`sending`), e a camada de integração executa a comunicação com o fisco.
+* Possíveis resultados padrão:
+
+  * **Autorizado** (`authorized`): autorização concluída com protocolo e XML
+    de retorno.
+  * **Rejeitado** (`rejected`): erros de validação retornados pelo fisco.
+    O usuário corrige o documento e pode enviar novamente.
+  * **Denegado** (`denied`): irregularidade fiscal. Em geral, representa um
+    estado final para aquela numeração.
+
+* Observação: para documentos não eletrônicos (ou sem processador), o fluxo de
+  envio pode finalizar diretamente em **Autorizado** conforme a implementação.
+
+3. Cancelamento (`*` -> `cancel`)
+---------------------------------
+
+* O estado **Cancelado** (`cancel`) pode ser atingido a partir de múltiplos
+  estados no fluxo base (`authorized`, `open`, `rejected`, `draft`, `sending`).
+* Para documentos autorizados eletrônicos emitidos pela empresa, a ação de
+  cancelar abre assistente próprio para coleta/processamento da justificativa.
+* Para documentos ainda não autorizados, o cancelamento pode ocorrer
+  diretamente no fluxo local.
+
+4. Retorno para Rascunho (`*` -> `draft`)
+-----------------------------------------
+
+* O fluxo base permite retornar para **Rascunho** (`draft`) a partir de
+  `open`, `sending`, `rejected`, `cancel`, `denied` e também de `draft`
+  (idempotente).
+* Essa ação limpa informações transitórias de erro/relatório para permitir
+  nova preparação do documento.
+
+5. Eventos e correções
 ----------------------
-*   **Carta de Correção (CC-e):** Para documentos autorizados (como NF-e e CT-e), utilize a ação "Carta de Correção" para sanar erros em campos permitidos pela legislação.
-*   **Inutilização:** Caso uma numeração seja pulada acidentalmente ou por falha técnica, utilize a funcionalidade de Inutilização de Numeração (menu Fiscal > Inutilização) para reportar a faixa ao fisco.
 
-5. Visualização e PDF
----------------------
-*   Em estados válidos (Em Aberto, Autorizado), os botões **Visualizar XML** e **Visualizar PDF** permitem inspecionar o arquivo enviado e imprimir o DANFE/DACTE/DAMDFE correspondente.
+* **Carta de Correção (CC-e):** para documentos autorizados que suportam o
+  evento.
+* **Inutilização de Numeração:** para faixas de numeração não utilizadas,
+  conforme regras fiscais aplicáveis.
+
+6. Extensão do workflow por módulo fiscal
+-----------------------------------------
+
+A FSM deste módulo é projetada para extensão. Módulos de tipos fiscais
+específicos podem sobrescrever `get_state_machine_config()` e callbacks
+relacionados para:
+
+* incluir estados adicionais;
+* alterar transições válidas;
+* personalizar regras de pré/pós-transição;
+* adaptar o fluxo ao comportamento dos webservices de cada documento.

--- a/l10n_br_fiscal_edi/static/description/fsm_graph.dot
+++ b/l10n_br_fiscal_edi/static/description/fsm_graph.dot
@@ -37,4 +37,5 @@ digraph FSM {
     rejected -> draft [label="Set to Draft", color="gray"];
     cancel -> draft [label="Set to Draft", color="gray"];
     denied -> draft [label="Set to Draft", color="gray"];
+    draft -> draft [label="Set to Draft (Idempotent)", style="dotted", color="gray"];
 }


### PR DESCRIPTION
### Motivation

* Align documentation with the real FSM implemented in `l10n_br_fiscal_edi/models/document.py`, ensuring the diagram and usage text reflect actual transitions and behaviors.
* Make explicit that the FSM is extensible and can be overridden per fiscal document via `get_state_machine_config()`. 
* Document the non-electronic / no-processor path that may lead directly to `authorized` to avoid confusion.

### Description

* Added the idempotent `draft -> draft` transition to `l10n_br_fiscal_edi/static/description/fsm_graph.dot` to represent `action_draft_fsm` allowing a no-op back-to-draft. 
* Rewrote `l10n_br_fiscal_edi/readme/DESCRIPTION.md` to use the module's canonical state names and to call out FSM extensibility via `get_state_machine_config()`. 
* Rewrote `l10n_br_fiscal_edi/readme/USAGE.md` to match implemented flows (states `draft`, `open`, `sending`, `authorized`, `rejected`, `denied`, `cancel`), to document the cancel-from-many-states behavior, the back-to-draft idempotency, and the non-electronic / processor-less immediate-authorization path. 
* Did not regenerate `fsm_graph.png` because Graphviz (`dot`) is not available in this environment, so only the `.dot` source was updated.

### Testing

* Ran `git diff --check` to validate the working tree and it reported no issues. 
* Performed static verification by comparing the documented transitions with `get_state_machine_config()` in `l10n_br_fiscal_edi/models/document.py` using `rg`/manual inspection and ensured the docs reflect the code. 
* Executed `dot -V` to regenerate diagram and it failed because Graphviz is not installed in the environment, so image regeneration was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21744fb4083318adbd64b1e03ca2e)