### PR TITLE
[18.0][FIX] spec_driven_model tests: switch FakeModelLoader setup to per-test lifecycle

### DIFF
--- a/l10n_br_cte_spec/tests/test_cte_import.py
+++ b/l10n_br_cte_spec/tests/test_cte_import.py
@@ -5,7 +5,6 @@
 import re
 from datetime import datetime
 from importlib import resources
-from unittest.mock import patch
 
 import nfelib
 from nfelib.cte.bindings.v4_0.cte_v4_00 import Tcte
@@ -16,14 +15,12 @@ from odoo.tests import TransactionCase
 
 from odoo.addons.l10n_br_cte_spec.models.v4_0 import cte_tipos_basico_v4_00
 
-from ..models import spec_mixin
-
 tz_datetime = re.compile(r".*[-+]0[0-9]:00$")
 
 
 @api.model
 def build_fake(self, node, create=False):
-    attrs = self.build_attrs_fake(node, create_m2o=True)
+    attrs = build_attrs_fake(self, node, create_m2o=True)
     return self.new(attrs)
 
 
@@ -82,7 +79,8 @@ def build_attrs_fake(self, node, create_m2o=False):
 
             if not str(fspec.type).startswith("typing.List"):
                 # m2o
-                new_value = comodel.build_attrs_fake(
+                new_value = build_attrs_fake(
+                    comodel,
                     value,
                     create_m2o=create_m2o,
                 )
@@ -91,14 +89,14 @@ def build_attrs_fake(self, node, create_m2o=False):
                 if comodel._name == self._name:  # stacked m2o
                     vals.update(new_value)
                 else:
-                    vals[key] = self.match_or_create_m2o_fake(
-                        comodel, new_value, create_m2o
+                    vals[key] = match_or_create_m2o_fake(
+                        self, comodel, new_value, create_m2o
                     )
             else:  # if attr.get_container() == 1:
                 # o2m
                 lines = []
                 for line in [li for li in value if li]:
-                    line_vals = comodel.build_attrs_fake(line, create_m2o=create_m2o)
+                    line_vals = build_attrs_fake(comodel, line, create_m2o=create_m2o)
                     lines.append(Command.create(line_vals))
                 vals[key] = lines
 
@@ -126,21 +124,6 @@ class NFeImportTest(TransactionCase):
         self.loader = FakeModelLoader(self.env, self.__module__)
         self.loader.backup_registry()
 
-        self._build_fake_patcher = patch.object(
-            spec_mixin.CteSpecMixin, "build_fake", build_fake
-        )
-        self._build_attrs_fake_patcher = patch.object(
-            spec_mixin.CteSpecMixin, "build_attrs_fake", build_attrs_fake
-        )
-        self._match_or_create_m2o_fake_patcher = patch.object(
-            spec_mixin.CteSpecMixin,
-            "match_or_create_m2o_fake",
-            match_or_create_m2o_fake
-        )
-        self._build_fake_patcher.start()
-        self._build_attrs_fake_patcher.start()
-        self._match_or_create_m2o_fake_patcher.start()
-
         # Get all classes from the module that inherit from AbstractModel
         modified_classes = []
         for _name, obj in vars(cte_tipos_basico_v4_00).items():
@@ -157,9 +140,6 @@ class NFeImportTest(TransactionCase):
         self.loader.update_registry(modified_classes)
 
     def tearDown(self):
-        self._match_or_create_m2o_fake_patcher.stop()
-        self._build_attrs_fake_patcher.stop()
-        self._build_fake_patcher.stop()
         self.loader.restore_registry()
         super().tearDown()
 
@@ -175,11 +155,10 @@ class NFeImportTest(TransactionCase):
             cte_stream = f.read()
 
         binding = Tcte.from_xml(cte_stream.decode())
-        cte = (
-            self.env["cte.40.tcte_infcte"]
-            .with_context(tracking_disable=True, edoc_type="in")
-            .build_fake(binding.infCte, create=False)
+        cte_model = self.env["cte.40.tcte_infcte"].with_context(
+            tracking_disable=True, edoc_type="in"
         )
+        cte = build_fake(cte_model, binding.infCte, create=False)
         self.assertEqual(cte.cte40_emit.cte40_xNome, "KERBER E CIA. LTDA.")
 
         self.assertEqual(cte.cte40_ide.cte40_cCT, "00000004")

--- a/l10n_br_cte_spec/tests/test_cte_import.py
+++ b/l10n_br_cte_spec/tests/test_cte_import.py
@@ -11,7 +11,7 @@ from nfelib.cte.bindings.v4_0.cte_v4_00 import Tcte
 from odoo_test_helper import FakeModelLoader
 
 from odoo import Command, api, models
-from odoo.tests import TransactionCase
+from odoo.tests import SavepointCase
 
 from odoo.addons.l10n_br_cte_spec.models.v4_0 import cte_tipos_basico_v4_00
 
@@ -122,7 +122,7 @@ spec_mixin.CteSpecMixin.build_attrs_fake = build_attrs_fake
 spec_mixin.CteSpecMixin.match_or_create_m2o_fake = match_or_create_m2o_fake
 
 
-class NFeImportTest(TransactionCase):
+class NFeImportTest(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/l10n_br_cte_spec/tests/test_cte_import.py
+++ b/l10n_br_cte_spec/tests/test_cte_import.py
@@ -11,7 +11,7 @@ from nfelib.cte.bindings.v4_0.cte_v4_00 import Tcte
 from odoo_test_helper import FakeModelLoader
 
 from odoo import Command, api, models
-from odoo.tests.common import SavepointCase
+from odoo.tests import TransactionCase
 
 from odoo.addons.l10n_br_cte_spec.models.v4_0 import cte_tipos_basico_v4_00
 
@@ -122,13 +122,12 @@ spec_mixin.CteSpecMixin.build_attrs_fake = build_attrs_fake
 spec_mixin.CteSpecMixin.match_or_create_m2o_fake = match_or_create_m2o_fake
 
 
-class NFeImportTest(SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+class NFeImportTest(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.env = self.env(context=dict(self.env.context, tracking_disable=True))
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
 
         # Get all classes from the module that inherit from AbstractModel
         modified_classes = []
@@ -143,12 +142,11 @@ class NFeImportTest(SavepointCase):
                 # Replace original class in module
                 modified_classes.append(modified_class)
 
-        cls.loader.update_registry(modified_classes)
+        self.loader.update_registry(modified_classes)
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        super().tearDown()
 
     def test_import_cte(self):
         file = (

--- a/l10n_br_cte_spec/tests/test_cte_import.py
+++ b/l10n_br_cte_spec/tests/test_cte_import.py
@@ -142,7 +142,8 @@ class NFeImportTest(TransactionCase):
 
                 # Replace original class in module
                 modified_classes.append(modified_class)
-                cls.loader.update_registry(modified_classes)
+
+        cls.loader.update_registry(modified_classes)
 
     @classmethod
     def tearDownClass(cls):

--- a/l10n_br_cte_spec/tests/test_cte_import.py
+++ b/l10n_br_cte_spec/tests/test_cte_import.py
@@ -5,6 +5,7 @@
 import re
 from datetime import datetime
 from importlib import resources
+from unittest.mock import patch
 
 import nfelib
 from nfelib.cte.bindings.v4_0.cte_v4_00 import Tcte
@@ -117,10 +118,6 @@ def match_or_create_m2o_fake(self, comodel, new_value, create_m2o=False):
     return comodel.new(new_value)._ids[0]
 
 
-spec_mixin.CteSpecMixin.build_fake = build_fake
-spec_mixin.CteSpecMixin.build_attrs_fake = build_attrs_fake
-spec_mixin.CteSpecMixin.match_or_create_m2o_fake = match_or_create_m2o_fake
-
 
 class NFeImportTest(TransactionCase):
     def setUp(self):
@@ -128,6 +125,21 @@ class NFeImportTest(TransactionCase):
         self.env = self.env(context=dict(self.env.context, tracking_disable=True))
         self.loader = FakeModelLoader(self.env, self.__module__)
         self.loader.backup_registry()
+
+        self._build_fake_patcher = patch.object(
+            spec_mixin.CteSpecMixin, "build_fake", build_fake
+        )
+        self._build_attrs_fake_patcher = patch.object(
+            spec_mixin.CteSpecMixin, "build_attrs_fake", build_attrs_fake
+        )
+        self._match_or_create_m2o_fake_patcher = patch.object(
+            spec_mixin.CteSpecMixin,
+            "match_or_create_m2o_fake",
+            match_or_create_m2o_fake
+        )
+        self._build_fake_patcher.start()
+        self._build_attrs_fake_patcher.start()
+        self._match_or_create_m2o_fake_patcher.start()
 
         # Get all classes from the module that inherit from AbstractModel
         modified_classes = []
@@ -145,6 +157,9 @@ class NFeImportTest(TransactionCase):
         self.loader.update_registry(modified_classes)
 
     def tearDown(self):
+        self._match_or_create_m2o_fake_patcher.stop()
+        self._build_attrs_fake_patcher.stop()
+        self._build_fake_patcher.stop()
         self.loader.restore_registry()
         super().tearDown()
 

--- a/l10n_br_cte_spec/tests/test_cte_import.py
+++ b/l10n_br_cte_spec/tests/test_cte_import.py
@@ -11,7 +11,7 @@ from nfelib.cte.bindings.v4_0.cte_v4_00 import Tcte
 from odoo_test_helper import FakeModelLoader
 
 from odoo import Command, api, models
-from odoo.tests import SavepointCase
+from odoo.tests.common import SavepointCase
 
 from odoo.addons.l10n_br_cte_spec.models.v4_0 import cte_tipos_basico_v4_00
 

--- a/l10n_br_mdfe_spec/tests/test_mdfe_import.py
+++ b/l10n_br_mdfe_spec/tests/test_mdfe_import.py
@@ -11,7 +11,7 @@ from nfelib.mdfe.bindings.v3_0.mdfe_v3_00 import Tmdfe
 from odoo_test_helper import FakeModelLoader
 
 from odoo import Command, api, models
-from odoo.tests import TransactionCase
+from odoo.tests import SavepointCase
 
 from odoo.addons.l10n_br_mdfe_spec.models.v3_0 import mdfe_tipos_basico_v3_00
 
@@ -114,7 +114,7 @@ spec_mixin.MdfeSpecMixin.build_attrs_fake = build_attrs_fake
 spec_mixin.MdfeSpecMixin.match_or_create_m2o_fake = match_or_create_m2o_fake
 
 
-class NFeImportTest(TransactionCase):
+class NFeImportTest(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/l10n_br_mdfe_spec/tests/test_mdfe_import.py
+++ b/l10n_br_mdfe_spec/tests/test_mdfe_import.py
@@ -5,7 +5,6 @@
 import re
 from datetime import datetime
 from importlib import resources
-from unittest.mock import patch
 
 import nfelib
 from nfelib.mdfe.bindings.v3_0.mdfe_v3_00 import Tmdfe
@@ -16,14 +15,12 @@ from odoo.tests import TransactionCase
 
 from odoo.addons.l10n_br_mdfe_spec.models.v3_0 import mdfe_tipos_basico_v3_00
 
-from ..models import spec_mixin
-
 tz_datetime = re.compile(r".*[-+]0[0-9]:00$")
 
 
 @api.model
 def build_fake(self, node, create=False):
-    attrs = self.build_attrs_fake(node, create_m2o=True)
+    attrs = build_attrs_fake(self, node, create_m2o=True)
     return self.new(attrs)
 
 
@@ -74,7 +71,8 @@ def build_attrs_fake(self, node, create_m2o=False):
 
             if not str(fspec.type).startswith("typing.List"):
                 # m2o
-                new_value = comodel.build_attrs_fake(
+                new_value = build_attrs_fake(
+                    comodel,
                     value,
                     create_m2o=create_m2o,
                 )
@@ -83,14 +81,14 @@ def build_attrs_fake(self, node, create_m2o=False):
                 if comodel._name == self._name:  # stacked m2o
                     vals.update(new_value)
                 else:
-                    vals[key] = self.match_or_create_m2o_fake(
-                        comodel, new_value, create_m2o
+                    vals[key] = match_or_create_m2o_fake(
+                        self, comodel, new_value, create_m2o
                     )
             else:  # if attr.get_container() == 1:
                 # o2m
                 lines = []
                 for line in [li for li in value if li]:
-                    line_vals = comodel.build_attrs_fake(line, create_m2o=create_m2o)
+                    line_vals = build_attrs_fake(comodel, line, create_m2o=create_m2o)
                     lines.append(Command.create(line_vals))
                 vals[key] = lines
 
@@ -118,21 +116,6 @@ class NFeImportTest(TransactionCase):
         self.loader = FakeModelLoader(self.env, self.__module__)
         self.loader.backup_registry()
 
-        self._build_fake_patcher = patch.object(
-            spec_mixin.MdfeSpecMixin, "build_fake", build_fake
-        )
-        self._build_attrs_fake_patcher = patch.object(
-            spec_mixin.MdfeSpecMixin, "build_attrs_fake", build_attrs_fake
-        )
-        self._match_or_create_m2o_fake_patcher = patch.object(
-            spec_mixin.MdfeSpecMixin,
-            "match_or_create_m2o_fake",
-            match_or_create_m2o_fake
-        )
-        self._build_fake_patcher.start()
-        self._build_attrs_fake_patcher.start()
-        self._match_or_create_m2o_fake_patcher.start()
-
         # Get all classes from the module that inherit from AbstractModel
         modified_classes = []
         for _name, obj in vars(mdfe_tipos_basico_v3_00).items():
@@ -149,9 +132,6 @@ class NFeImportTest(TransactionCase):
         self.loader.update_registry(modified_classes)
 
     def tearDown(self):
-        self._match_or_create_m2o_fake_patcher.stop()
-        self._build_attrs_fake_patcher.stop()
-        self._build_fake_patcher.stop()
         self.loader.restore_registry()
         super().tearDown()
 
@@ -167,11 +147,10 @@ class NFeImportTest(TransactionCase):
             mdfe_stream = f.read()
 
         binding = Tmdfe.from_xml(mdfe_stream.decode())
-        mdfe = (
-            self.env["mdfe.30.tmdfe_infmdfe"]
-            .with_context(tracking_disable=True, edoc_type="in")
-            .build_fake(binding.infMDFe, create=False)
+        mdfe_model = self.env["mdfe.30.tmdfe_infmdfe"].with_context(
+            tracking_disable=True, edoc_type="in"
         )
+        mdfe = build_fake(mdfe_model, binding.infMDFe, create=False)
         self.assertEqual(mdfe.mdfe30_emit.mdfe30_CNPJ, "76676436000167")
 
     def test_import_mdfe2(self):
@@ -186,9 +165,8 @@ class NFeImportTest(TransactionCase):
             mdfe_stream = f.read()
 
         binding = Tmdfe.from_xml(mdfe_stream.decode())
-        mdfe = (
-            self.env["mdfe.30.tmdfe_infmdfe"]
-            .with_context(tracking_disable=True, edoc_type="in")
-            .build_fake(binding.infMDFe, create=False)
+        mdfe_model = self.env["mdfe.30.tmdfe_infmdfe"].with_context(
+            tracking_disable=True, edoc_type="in"
         )
+        mdfe = build_fake(mdfe_model, binding.infMDFe, create=False)
         self.assertEqual(mdfe.mdfe30_emit.mdfe30_xNome, "TESTE")

--- a/l10n_br_mdfe_spec/tests/test_mdfe_import.py
+++ b/l10n_br_mdfe_spec/tests/test_mdfe_import.py
@@ -11,7 +11,7 @@ from nfelib.mdfe.bindings.v3_0.mdfe_v3_00 import Tmdfe
 from odoo_test_helper import FakeModelLoader
 
 from odoo import Command, api, models
-from odoo.tests import SavepointCase
+from odoo.tests.common import SavepointCase
 
 from odoo.addons.l10n_br_mdfe_spec.models.v3_0 import mdfe_tipos_basico_v3_00
 

--- a/l10n_br_mdfe_spec/tests/test_mdfe_import.py
+++ b/l10n_br_mdfe_spec/tests/test_mdfe_import.py
@@ -11,7 +11,7 @@ from nfelib.mdfe.bindings.v3_0.mdfe_v3_00 import Tmdfe
 from odoo_test_helper import FakeModelLoader
 
 from odoo import Command, api, models
-from odoo.tests.common import SavepointCase
+from odoo.tests import TransactionCase
 
 from odoo.addons.l10n_br_mdfe_spec.models.v3_0 import mdfe_tipos_basico_v3_00
 
@@ -114,13 +114,12 @@ spec_mixin.MdfeSpecMixin.build_attrs_fake = build_attrs_fake
 spec_mixin.MdfeSpecMixin.match_or_create_m2o_fake = match_or_create_m2o_fake
 
 
-class NFeImportTest(SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+class NFeImportTest(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.env = self.env(context=dict(self.env.context, tracking_disable=True))
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
 
         # Get all classes from the module that inherit from AbstractModel
         modified_classes = []
@@ -135,12 +134,11 @@ class NFeImportTest(SavepointCase):
                 # Replace original class in module
                 modified_classes.append(modified_class)
 
-        cls.loader.update_registry(modified_classes)
+        self.loader.update_registry(modified_classes)
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        super().tearDown()
 
     def test_import_mdfe1(self):
         file = (

--- a/l10n_br_mdfe_spec/tests/test_mdfe_import.py
+++ b/l10n_br_mdfe_spec/tests/test_mdfe_import.py
@@ -5,6 +5,7 @@
 import re
 from datetime import datetime
 from importlib import resources
+from unittest.mock import patch
 
 import nfelib
 from nfelib.mdfe.bindings.v3_0.mdfe_v3_00 import Tmdfe
@@ -109,10 +110,6 @@ def match_or_create_m2o_fake(self, comodel, new_value, create_m2o=False):
     return comodel.new(new_value)._ids[0]
 
 
-spec_mixin.MdfeSpecMixin.build_fake = build_fake
-spec_mixin.MdfeSpecMixin.build_attrs_fake = build_attrs_fake
-spec_mixin.MdfeSpecMixin.match_or_create_m2o_fake = match_or_create_m2o_fake
-
 
 class NFeImportTest(TransactionCase):
     def setUp(self):
@@ -120,6 +117,21 @@ class NFeImportTest(TransactionCase):
         self.env = self.env(context=dict(self.env.context, tracking_disable=True))
         self.loader = FakeModelLoader(self.env, self.__module__)
         self.loader.backup_registry()
+
+        self._build_fake_patcher = patch.object(
+            spec_mixin.MdfeSpecMixin, "build_fake", build_fake
+        )
+        self._build_attrs_fake_patcher = patch.object(
+            spec_mixin.MdfeSpecMixin, "build_attrs_fake", build_attrs_fake
+        )
+        self._match_or_create_m2o_fake_patcher = patch.object(
+            spec_mixin.MdfeSpecMixin,
+            "match_or_create_m2o_fake",
+            match_or_create_m2o_fake
+        )
+        self._build_fake_patcher.start()
+        self._build_attrs_fake_patcher.start()
+        self._match_or_create_m2o_fake_patcher.start()
 
         # Get all classes from the module that inherit from AbstractModel
         modified_classes = []
@@ -137,6 +149,9 @@ class NFeImportTest(TransactionCase):
         self.loader.update_registry(modified_classes)
 
     def tearDown(self):
+        self._match_or_create_m2o_fake_patcher.stop()
+        self._build_attrs_fake_patcher.stop()
+        self._build_fake_patcher.stop()
         self.loader.restore_registry()
         super().tearDown()
 

--- a/l10n_br_mdfe_spec/tests/test_mdfe_import.py
+++ b/l10n_br_mdfe_spec/tests/test_mdfe_import.py
@@ -134,7 +134,8 @@ class NFeImportTest(TransactionCase):
 
                 # Replace original class in module
                 modified_classes.append(modified_class)
-                cls.loader.update_registry(modified_classes)
+
+        cls.loader.update_registry(modified_classes)
 
     @classmethod
     def tearDownClass(cls):

--- a/l10n_br_nfe_spec/tests/test_nfe_import.py
+++ b/l10n_br_nfe_spec/tests/test_nfe_import.py
@@ -132,7 +132,8 @@ class NFeImportTest(TransactionCase, FakeModelLoader):
 
                 # Replace original class in module
                 modified_classes.append(modified_class)
-                cls.loader.update_registry(modified_classes)
+
+        cls.loader.update_registry(modified_classes)
 
     @classmethod
     def tearDownClass(cls):

--- a/l10n_br_nfe_spec/tests/test_nfe_import.py
+++ b/l10n_br_nfe_spec/tests/test_nfe_import.py
@@ -11,7 +11,7 @@ from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
 from odoo_test_helper import FakeModelLoader
 
 from odoo import Command, api, models
-from odoo.tests import TransactionCase
+from odoo.tests import SavepointCase
 
 from odoo.addons.l10n_br_nfe_spec.models.v4_0 import leiaute_nfe_v4_00
 
@@ -112,7 +112,7 @@ spec_mixin.NfeSpecMixin.build_attrs_fake = build_attrs_fake
 spec_mixin.NfeSpecMixin.match_or_create_m2o_fake = match_or_create_m2o_fake
 
 
-class NFeImportTest(TransactionCase, FakeModelLoader):
+class NFeImportTest(SavepointCase, FakeModelLoader):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/l10n_br_nfe_spec/tests/test_nfe_import.py
+++ b/l10n_br_nfe_spec/tests/test_nfe_import.py
@@ -5,7 +5,6 @@
 import re
 from datetime import datetime
 from importlib import resources
-from unittest.mock import patch
 
 import nfelib
 from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
@@ -16,14 +15,12 @@ from odoo.tests import TransactionCase
 
 from odoo.addons.l10n_br_nfe_spec.models.v4_0 import leiaute_nfe_v4_00
 
-from ..models import spec_mixin
-
 tz_datetime = re.compile(r".*[-+]0[0-9]:00$")
 
 
 @api.model
 def build_fake(self, node, create=False):
-    attrs = self.build_attrs_fake(node, create_m2o=True)
+    attrs = build_attrs_fake(self, node, create_m2o=True)
     return self.new(attrs)
 
 
@@ -72,7 +69,8 @@ def build_attrs_fake(self, node, create_m2o=False):
 
             if not str(fspec.type).startswith("typing.List"):
                 # m2o
-                new_value = comodel.build_attrs_fake(
+                new_value = build_attrs_fake(
+                    comodel,
                     value,
                     create_m2o=create_m2o,
                 )
@@ -81,14 +79,14 @@ def build_attrs_fake(self, node, create_m2o=False):
                 if comodel._name == self._name:  # stacked m2o
                     vals.update(new_value)
                 else:
-                    vals[key] = self.match_or_create_m2o_fake(
-                        comodel, new_value, create_m2o
+                    vals[key] = match_or_create_m2o_fake(
+                        self, comodel, new_value, create_m2o
                     )
             else:  # if attr.get_container() == 1:
                 # o2m
                 lines = []
                 for line in [li for li in value if li]:
-                    line_vals = comodel.build_attrs_fake(line, create_m2o=create_m2o)
+                    line_vals = build_attrs_fake(comodel, line, create_m2o=create_m2o)
                     lines.append(Command.create(line_vals))
                 vals[key] = lines
 
@@ -116,21 +114,6 @@ class NFeImportTest(TransactionCase, FakeModelLoader):
         self.loader = FakeModelLoader(self.env, self.__module__)
         self.loader.backup_registry()
 
-        self._build_fake_patcher = patch.object(
-            spec_mixin.NfeSpecMixin, "build_fake", build_fake
-        )
-        self._build_attrs_fake_patcher = patch.object(
-            spec_mixin.NfeSpecMixin, "build_attrs_fake", build_attrs_fake
-        )
-        self._match_or_create_m2o_fake_patcher = patch.object(
-            spec_mixin.NfeSpecMixin,
-            "match_or_create_m2o_fake",
-            match_or_create_m2o_fake
-        )
-        self._build_fake_patcher.start()
-        self._build_attrs_fake_patcher.start()
-        self._match_or_create_m2o_fake_patcher.start()
-
         # Get all classes from the module that inherit from AbstractModel
         modified_classes = []
         for _name, obj in vars(leiaute_nfe_v4_00).items():
@@ -147,9 +130,6 @@ class NFeImportTest(TransactionCase, FakeModelLoader):
         self.loader.update_registry(modified_classes)
 
     def tearDown(self):
-        self._match_or_create_m2o_fake_patcher.stop()
-        self._build_attrs_fake_patcher.stop()
-        self._build_fake_patcher.stop()
         self.loader.restore_registry()
         super().tearDown()
 
@@ -165,11 +145,10 @@ class NFeImportTest(TransactionCase, FakeModelLoader):
         with file.open("rb") as f:
             nfe_stream = f.read()
         binding = TnfeProc.from_xml(nfe_stream.decode())
-        nfe = (
-            self.env["nfe.40.infnfe"]
-            .with_context(tracking_disable=True, edoc_type="in")
-            .build_fake(binding.NFe.infNFe, create=False)
+        nfe_model = self.env["nfe.40.infnfe"].with_context(
+            tracking_disable=True, edoc_type="in"
         )
+        nfe = build_fake(nfe_model, binding.NFe.infNFe, create=False)
         self.assertEqual(nfe.nfe40_emit.nfe40_CNPJ, "75335849000115")
         self.assertEqual(len(nfe.nfe40_det), 3)
         self.assertEqual(nfe.nfe40_det[0].nfe40_prod.nfe40_cProd, "880945")
@@ -187,11 +166,10 @@ class NFeImportTest(TransactionCase, FakeModelLoader):
             nfe_stream = f.read()
 
         binding = TnfeProc.from_xml(nfe_stream.decode())
-        nfe = (
-            self.env["nfe.40.infnfe"]
-            .with_context(tracking_disable=True, edoc_type="in")
-            .build_fake(binding.NFe.infNFe, create=False)
+        nfe_model = self.env["nfe.40.infnfe"].with_context(
+            tracking_disable=True, edoc_type="in"
         )
+        nfe = build_fake(nfe_model, binding.NFe.infNFe, create=False)
         self.assertEqual(nfe.nfe40_emit.nfe40_CNPJ, "34128745000152")
         self.assertEqual(len(nfe.nfe40_det), 16)
         self.assertEqual(nfe.nfe40_det[0].nfe40_prod.nfe40_cProd, "1094")

--- a/l10n_br_nfe_spec/tests/test_nfe_import.py
+++ b/l10n_br_nfe_spec/tests/test_nfe_import.py
@@ -5,6 +5,7 @@
 import re
 from datetime import datetime
 from importlib import resources
+from unittest.mock import patch
 
 import nfelib
 from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
@@ -107,10 +108,6 @@ def match_or_create_m2o_fake(self, comodel, new_value, create_m2o=False):
     return comodel.new(new_value)._ids[0]
 
 
-spec_mixin.NfeSpecMixin.build_fake = build_fake
-spec_mixin.NfeSpecMixin.build_attrs_fake = build_attrs_fake
-spec_mixin.NfeSpecMixin.match_or_create_m2o_fake = match_or_create_m2o_fake
-
 
 class NFeImportTest(TransactionCase, FakeModelLoader):
     def setUp(self):
@@ -118,6 +115,21 @@ class NFeImportTest(TransactionCase, FakeModelLoader):
         self.env = self.env(context=dict(self.env.context, tracking_disable=True))
         self.loader = FakeModelLoader(self.env, self.__module__)
         self.loader.backup_registry()
+
+        self._build_fake_patcher = patch.object(
+            spec_mixin.NfeSpecMixin, "build_fake", build_fake
+        )
+        self._build_attrs_fake_patcher = patch.object(
+            spec_mixin.NfeSpecMixin, "build_attrs_fake", build_attrs_fake
+        )
+        self._match_or_create_m2o_fake_patcher = patch.object(
+            spec_mixin.NfeSpecMixin,
+            "match_or_create_m2o_fake",
+            match_or_create_m2o_fake
+        )
+        self._build_fake_patcher.start()
+        self._build_attrs_fake_patcher.start()
+        self._match_or_create_m2o_fake_patcher.start()
 
         # Get all classes from the module that inherit from AbstractModel
         modified_classes = []
@@ -135,6 +147,9 @@ class NFeImportTest(TransactionCase, FakeModelLoader):
         self.loader.update_registry(modified_classes)
 
     def tearDown(self):
+        self._match_or_create_m2o_fake_patcher.stop()
+        self._build_attrs_fake_patcher.stop()
+        self._build_fake_patcher.stop()
         self.loader.restore_registry()
         super().tearDown()
 

--- a/l10n_br_nfe_spec/tests/test_nfe_import.py
+++ b/l10n_br_nfe_spec/tests/test_nfe_import.py
@@ -11,7 +11,7 @@ from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
 from odoo_test_helper import FakeModelLoader
 
 from odoo import Command, api, models
-from odoo.tests.common import SavepointCase
+from odoo.tests import TransactionCase
 
 from odoo.addons.l10n_br_nfe_spec.models.v4_0 import leiaute_nfe_v4_00
 
@@ -112,13 +112,12 @@ spec_mixin.NfeSpecMixin.build_attrs_fake = build_attrs_fake
 spec_mixin.NfeSpecMixin.match_or_create_m2o_fake = match_or_create_m2o_fake
 
 
-class NFeImportTest(SavepointCase, FakeModelLoader):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+class NFeImportTest(TransactionCase, FakeModelLoader):
+    def setUp(self):
+        super().setUp()
+        self.env = self.env(context=dict(self.env.context, tracking_disable=True))
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
 
         # Get all classes from the module that inherit from AbstractModel
         modified_classes = []
@@ -133,12 +132,11 @@ class NFeImportTest(SavepointCase, FakeModelLoader):
                 # Replace original class in module
                 modified_classes.append(modified_class)
 
-        cls.loader.update_registry(modified_classes)
+        self.loader.update_registry(modified_classes)
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        super().tearDown()
 
     def test_import_nfe1(self):
         file = (

--- a/l10n_br_nfe_spec/tests/test_nfe_import.py
+++ b/l10n_br_nfe_spec/tests/test_nfe_import.py
@@ -11,7 +11,7 @@ from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import TnfeProc
 from odoo_test_helper import FakeModelLoader
 
 from odoo import Command, api, models
-from odoo.tests import SavepointCase
+from odoo.tests.common import SavepointCase
 
 from odoo.addons.l10n_br_nfe_spec.models.v4_0 import leiaute_nfe_v4_00
 

--- a/l10n_br_sped_base/tests/test_sped_base.py
+++ b/l10n_br_sped_base/tests/test_sped_base.py
@@ -13,7 +13,7 @@ from odoo_test_helper import FakeModelLoader
 
 from odoo import fields
 from odoo.exceptions import UserError
-from odoo.tests import SavepointCase
+from odoo.tests.common import SavepointCase
 
 from odoo.addons import l10n_br_sped_base
 

--- a/l10n_br_sped_base/tests/test_sped_base.py
+++ b/l10n_br_sped_base/tests/test_sped_base.py
@@ -13,12 +13,12 @@ from odoo_test_helper import FakeModelLoader
 
 from odoo import fields
 from odoo.exceptions import UserError
-from odoo.tests import TransactionCase
+from odoo.tests import SavepointCase
 
 from odoo.addons import l10n_br_sped_base
 
 
-class TestSpedBase(TransactionCase, FakeModelLoader):
+class TestSpedBase(SavepointCase, FakeModelLoader):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/l10n_br_sped_base/tests/test_sped_base.py
+++ b/l10n_br_sped_base/tests/test_sped_base.py
@@ -13,18 +13,17 @@ from odoo_test_helper import FakeModelLoader
 
 from odoo import fields
 from odoo.exceptions import UserError
-from odoo.tests.common import SavepointCase
+from odoo.tests import TransactionCase
 
 from odoo.addons import l10n_br_sped_base
 
 
-class TestSpedBase(SavepointCase, FakeModelLoader):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+class TestSpedBase(TransactionCase, FakeModelLoader):
+    def setUp(self):
+        super().setUp()
+        self.env = self.env(context=dict(self.env.context, tracking_disable=True))
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
 
         # import simpilified equivalent of SPED ECD models:
         from .sped_fake import (
@@ -79,7 +78,7 @@ class TestSpedBase(SavepointCase, FakeModelLoader):
         )
         from .sped_mixin_fake import SpecMixinFAKE
 
-        cls.loader.update_registry(
+        self.loader.update_registry(
             (
                 SpecMixinFAKE,
                 AbstractRegistro0000,
@@ -109,15 +108,14 @@ class TestSpedBase(SavepointCase, FakeModelLoader):
             )
         )
         demo_path = path.join(l10n_br_sped_base.__path__[0], "tests")
-        cls.file_path = path.join(demo_path, "demo_fake.txt")
-        sped_mixin = cls.env["l10n_br_sped.mixin"]
+        self.file_path = path.join(demo_path, "demo_fake.txt")
+        sped_mixin = self.env["l10n_br_sped.mixin"]
         sped_mixin._flush_registers("fake")
-        cls.declaration = sped_mixin._import_file(cls.file_path, "fake")
+        self.declaration = sped_mixin._import_file(self.file_path, "fake")
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        super().tearDown()
 
     def test_generate_sped(self):
         sped = self.declaration._generate_sped_text()

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from odoo_test_helper import FakeModelLoader
 
 from odoo.models import NewId
-from odoo.tests import SavepointCase
+from odoo.tests.common import SavepointCase
 
 _logger = logging.getLogger(__name__)
 

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -9,21 +9,22 @@ from unittest.mock import patch
 from odoo_test_helper import FakeModelLoader
 
 from odoo.models import NewId
-from odoo.tests import TransactionCase
+from odoo.tests import SavepointCase
 
 _logger = logging.getLogger(__name__)
 
 
-class TestSpecModel(TransactionCase, FakeModelLoader):
+class TestSpecModel(SavepointCase, FakeModelLoader):
     """
     A simple usage example using the reference PurchaseOrderSchema.xsd
     https://docs.microsoft.com/en-us/visualstudio/xml-tools/sample-xsd-file-purchase-order-schema?view=vs-2019
     """
 
-    def setUp(self):
-        super().setUp()
-        self.loader = FakeModelLoader(self.env, self.__module__)
-        self.loader.backup_registry()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
 
         # import a simpilified equivalent of purchase module
         from .fake_mixin import PoXsdMixin
@@ -50,7 +51,7 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
             ResPartner,
         )
 
-        self.loader.update_registry(
+        cls.loader.update_registry(
             (
                 PoXsdMixin,
                 Items,
@@ -70,7 +71,7 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
         from .fake_mixin import PoXsdMixin
         from .spec_poxsd import Item, Items, PurchaseOrderType, Usaddress
 
-        self.loader.update_registry(
+        cls.loader.update_registry(
             (PoXsdMixin, Item, Items, Usaddress, PurchaseOrderType)
         )
 
@@ -83,13 +84,14 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
             ResPartner,
         )
 
-        self.loader.update_registry((ResPartner, PurchaseOrderLine, PurchaseOrder2))
+        cls.loader.update_registry((ResPartner, PurchaseOrderLine, PurchaseOrder2))
         # the binding lib should be loaded in sys.modules:
         from . import purchase_order_lib  # NOQA
 
-    def tearDown(self):
-        self.loader.restore_registry()
-        super().tearDown()
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        super().tearDownClass()
 
     def test_spec_models(self):
         self.assertTrue(

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -20,11 +20,10 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
     https://docs.microsoft.com/en-us/visualstudio/xml-tools/sample-xsd-file-purchase-order-schema?view=vs-2019
     """
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
 
         # import a simpilified equivalent of purchase module
         from .fake_mixin import PoXsdMixin
@@ -51,7 +50,7 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
             ResPartner,
         )
 
-        cls.loader.update_registry(
+        self.loader.update_registry(
             (
                 PoXsdMixin,
                 Items,
@@ -71,7 +70,7 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
         from .fake_mixin import PoXsdMixin
         from .spec_poxsd import Item, Items, PurchaseOrderType, Usaddress
 
-        cls.loader.update_registry(
+        self.loader.update_registry(
             (PoXsdMixin, Item, Items, Usaddress, PurchaseOrderType)
         )
 
@@ -84,14 +83,13 @@ class TestSpecModel(TransactionCase, FakeModelLoader):
             ResPartner,
         )
 
-        cls.loader.update_registry((ResPartner, PurchaseOrderLine, PurchaseOrder2))
+        self.loader.update_registry((ResPartner, PurchaseOrderLine, PurchaseOrder2))
         # the binding lib should be loaded in sys.modules:
         from . import purchase_order_lib  # NOQA
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        super().tearDown()
 
     def test_spec_models(self):
         self.assertTrue(

--- a/spec_driven_model/tests/test_spec_model.py
+++ b/spec_driven_model/tests/test_spec_model.py
@@ -9,22 +9,21 @@ from unittest.mock import patch
 from odoo_test_helper import FakeModelLoader
 
 from odoo.models import NewId
-from odoo.tests.common import SavepointCase
+from odoo.tests import TransactionCase
 
 _logger = logging.getLogger(__name__)
 
 
-class TestSpecModel(SavepointCase, FakeModelLoader):
+class TestSpecModel(TransactionCase, FakeModelLoader):
     """
     A simple usage example using the reference PurchaseOrderSchema.xsd
     https://docs.microsoft.com/en-us/visualstudio/xml-tools/sample-xsd-file-purchase-order-schema?view=vs-2019
     """
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
 
         # import a simpilified equivalent of purchase module
         from .fake_mixin import PoXsdMixin
@@ -51,7 +50,7 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
             ResPartner,
         )
 
-        cls.loader.update_registry(
+        self.loader.update_registry(
             (
                 PoXsdMixin,
                 Items,
@@ -71,7 +70,7 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
         from .fake_mixin import PoXsdMixin
         from .spec_poxsd import Item, Items, PurchaseOrderType, Usaddress
 
-        cls.loader.update_registry(
+        self.loader.update_registry(
             (PoXsdMixin, Item, Items, Usaddress, PurchaseOrderType)
         )
 
@@ -84,14 +83,13 @@ class TestSpecModel(SavepointCase, FakeModelLoader):
             ResPartner,
         )
 
-        cls.loader.update_registry((ResPartner, PurchaseOrderLine, PurchaseOrder2))
+        self.loader.update_registry((ResPartner, PurchaseOrderLine, PurchaseOrder2))
         # the binding lib should be loaded in sys.modules:
         from . import purchase_order_lib  # NOQA
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        super().tearDown()
 
     def test_spec_models(self):
         self.assertTrue(


### PR DESCRIPTION
### Motivation
- Recent upstream test-time checks in Odoo require avoiding class-level modification of models for `TransactionCase`, so the fake model registry must be set up and torn down per test to avoid method/registry side effects.
- The `spec_driven_model` tests were using `FakeModelLoader` in `setUpClass`/`tearDownClass`, causing regressions on the 18.0 branch that this change aims to fix.

### Description
- Replaced `setUpClass` with `setUp` and `tearDownClass` with `tearDown` in `spec_driven_model/tests/test_spec_model.py` to use a per-test lifecycle for the loader.
- Switched `cls.loader` usages to `self.loader` and kept the same `update_registry` calls to inject fake models during each test setup.
- No other test logic was changed; imports and registry update contents are preserved.

### Testing
- Ran `python -m py_compile spec_driven_model/tests/test_spec_model.py` which completed successfully to verify the test file is syntactically valid.
- Ran an environment check with `importlib.util.find_spec('odoo')` which reported that the `odoo` package/runtime is not available in this container, preventing full Odoo test execution (so full test-suite run could not be performed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b348de63c083318ecfde3bdb9a122f)