### PR TITLE
[16.0][FIX] l10n_br_account_nfe: chNFE

### DIFF
--- a/l10n_br_account_nfe/tests/nfe/35231149647316000169550010000661061151600085-nfe.xml
+++ b/l10n_br_account_nfe/tests/nfe/35231149647316000169550010000661061151600085-nfe.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <nfeProc xmlns="http://www.portalfiscal.inf.br/nfe" versao="4.00">
   <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
-    <infNFe versao="4.00" Id="NFe35231149647316000169550010000661061151600085">
+    <infNFe versao="4.00" Id="NFe35261149647316000169550010000661061151600080">
       <ide>
         <cUF>35</cUF>
         <cNF>15160008</cNF>
@@ -481,7 +481,7 @@
     <infProt>
       <tpAmb>1</tpAmb>
       <verAplic>SP_NFE_PL009_V4</verAplic>
-      <chNFe>35231149647316000169550010000661061151600085</chNFe>
+      <chNFe>35261149647316000169550010000661061151600080</chNFe>
       <dhRecbto>2026-11-09T13:49:16-03:00</dhRecbto>
       <nProt>135231928909679</nProt>
       <digVal>VZsGaqFMX5OP0X855xlNRvL9rcc=</digVal>


### PR DESCRIPTION
@rvalyi Como você mudou a data da NF-e se tenta importar ela no Odoo e depois confirmar ela não e lança essa mensagem:
A data do documento não corresponde à data na chave do documento.
<img width="1914" height="347" alt="image" src="https://github.com/user-attachments/assets/06ebce40-3072-4a10-b137-52f2d7fefc2e" />

Objetivo do commit é corrigir a chave da NF-e para acompanhar a data da NF-e