### PR TITLE
[16.0] Sugestões da revisão do OCA#4494 (fix NFe import)

### DIFF
--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -756,6 +756,10 @@ class AccountMove(models.Model):
                     }
                 )
 
+                # amount_tax_(not_)included are NOT repeated here: they are
+                # delegated to the fiscal line through _inherits and writing
+                # them along with a new fiscal_document_line_id in the same
+                # vals would be ambiguous (old or new parent record?).
                 invoice_line_write_vals.append(
                     (
                         1,
@@ -764,8 +768,6 @@ class AccountMove(models.Model):
                             "product_uom_id": item["uot_id"],
                             "price_unit": item["price_unit"],
                             "fiscal_document_line_id": item["fiscal_line_id"],
-                            "amount_tax_included": item["amt_inc"],
-                            "amount_tax_not_included": item["amt_not_inc"],
                         },
                     )
                 )

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -780,8 +780,4 @@ class AccountMove(models.Model):
         if dummy_lines_to_unlink:
             dummy_lines_to_unlink.unlink()
 
-        # Recompute totals officially now that all lines are bound
-        # and tax_totals override is safely popped!
-        move.with_context(check_move_validity=True)._compute_amount()
-
         return move_form

--- a/l10n_br_account/models/account_move.py
+++ b/l10n_br_account/models/account_move.py
@@ -116,28 +116,27 @@ class AccountMove(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             self._sync_proxy_fields_vals(vals)
-            # Prevent Odoo's tax_totals widget from obliterating our
-            # exact XML tax calculations
-            if "tax_totals" in vals and (
-                vals.get("imported_document")
-                or self.env.context.get("force_fiscal_amount_recompute")
-            ):
-                vals.pop("tax_totals")
         return super().create(vals_list)
 
     def write(self, vals):
         self._sync_proxy_fields_vals(vals)
-        # Pop tax_totals to prevent Odoo from overriding our tax lines on save
-        if "tax_totals" in vals and (
-            any(self.mapped("imported_document"))
-            or self.env.context.get("force_fiscal_amount_recompute")
-        ):
-            vals.pop("tax_totals")
-
         res = super().write(vals)
         if "partner_id" in vals:
             self._onchange_ind_final()
         return res
+
+    def _inverse_tax_totals(self):
+        # Never let the tax_totals widget override the exact tax values
+        # of an imported fiscal document.
+        if self.env.context.get("force_fiscal_amount_recompute"):
+            # Import flow: the move is still being assembled and
+            # imported_document may not be written yet, so skip the
+            # inverse for the whole batch.
+            return
+        # Regular (UI) flow: run the standard inverse only for the moves
+        # that are not the mirror of an imported fiscal document.
+        moves = self.filtered(lambda move: not move.imported_document)
+        return super(AccountMove, moves)._inverse_tax_totals()
 
     @api.constrains("fiscal_document_id", "document_type_id")
     def _check_fiscal_document_type(self):

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -389,22 +389,7 @@ class AccountMoveLine(models.Model):
                 subtotal = line.quantity * line_discount_price_unit
                 line.price_total = line.price_subtotal = subtotal
 
-    # Ordered rules to classify an account.tax into a Brazilian tax kind
-    # from its domain/name. Each entry is (kind, include_kw, exclude_kw).
-    # Order matters: "icmsst" must be tested before "icms", etc.
-    _IMPORTED_TAX_MATCH_RULES = [
-        ("icmsst", ["icmsst", "icms_st", "icms st"], []),
-        ("icms", ["icms"], ["st", "wh", "ret"]),
-        ("ipi", ["ipi"], ["wh", "ret"]),
-        ("pis", ["pis"], ["st", "wh", "ret"]),
-        ("cofins", ["cofins"], ["st", "wh", "ret"]),
-        ("issqn", ["issqn", "iss"], ["inss", "wh", "ret"]),
-        ("ii", ["ii"], ["wh", "ret"]),
-        ("ibs", ["ibs"], ["wh", "ret"]),
-        ("cbs", ["cbs"], ["wh", "ret"]),
-    ]
-
-    # kind -> (fiscal_value_field, fiscal_base_field)
+    # tax_domain -> (fiscal_value_field, fiscal_base_field)
     _IMPORTED_TAX_FIELD_MAP = {
         "icmsst": ("icmsst_value", "icmsst_base"),
         "icms": ("icms_value", "icms_base"),
@@ -417,55 +402,32 @@ class AccountMoveLine(models.Model):
         "cbs": ("cbs_value", "cbs_base"),
     }
 
-    def _resolve_tax_kind(self, tax_dict):
-        """Resolve the Brazilian tax kind from a compute_all tax dict.
-
-        Tries the account.tax tax_domain first, then falls back to
-        heuristic name matching against ``_IMPORTED_TAX_MATCH_RULES``.
-        Returns a kind string (e.g. "icms") or "".
-        """
-        domain = ""
-        acc_tax = (
-            self.env["account.tax"].browse(tax_dict["id"])
-            if tax_dict.get("id")
-            else None
-        )
-        if not acc_tax and tax_dict.get("tax_repartition_line_id"):
-            acc_tax = (
-                self.env["account.tax.repartition.line"]
-                .browse(tax_dict["tax_repartition_line_id"])
-                .tax_id
-            )
-        if acc_tax:
-            if hasattr(acc_tax, "tax_domain") and acc_tax.tax_domain:
-                domain = acc_tax.tax_domain
-            elif hasattr(acc_tax, "fiscal_tax_ids") and acc_tax.fiscal_tax_ids:
-                domain = acc_tax.fiscal_tax_ids[0].tax_domain
-        if not domain:
-            domain = tax_dict.get("name", "").lower()
-
-        for kind, include_kw, exclude_kw in self._IMPORTED_TAX_MATCH_RULES:
-            if any(kw in domain for kw in include_kw) and not any(
-                kw in domain for kw in exclude_kw
-            ):
-                return kind
-        return ""
-
     def _override_taxes_from_import(self, taxes, fiscal_line, sign):
-        """Override compute_all tax amounts with imported fiscal values."""
+        """Override compute_all tax amounts with the imported fiscal values.
+
+        The account.tax -> Brazilian tax mapping comes from the fiscal
+        tax group (``tax_group_id.fiscal_tax_group_id.tax_domain``), the
+        same canonical link already used by the account.tax compute_all
+        override.
+        """
         for tax in taxes:
-            kind = self._resolve_tax_kind(tax)
-            fields = self._IMPORTED_TAX_FIELD_MAP.get(kind)
-            if fields:
-                tax["amount"] = sign * (getattr(fiscal_line, fields[0]) or 0.0)
-                tax["base"] = sign * (getattr(fiscal_line, fields[1]) or 0.0)
-            elif (
-                "wh" in tax.get("name", "").lower()
-                or "ret" in tax.get("name", "").lower()
-            ):
+            acc_tax = self.env["account.tax"].browse(tax.get("id") or [])
+            if not acc_tax and tax.get("tax_repartition_line_id"):
+                acc_tax = (
+                    self.env["account.tax.repartition.line"]
+                    .browse(tax["tax_repartition_line_id"])
+                    .tax_id
+                )
+            fiscal_group = acc_tax.tax_group_id.fiscal_tax_group_id
+            if fiscal_group.tax_withholding:
                 # Clear withholding taxes: XML doesn't bring WH item per item
                 tax["amount"] = 0.0
                 tax["base"] = 0.0
+                continue
+            field_names = self._IMPORTED_TAX_FIELD_MAP.get(fiscal_group.tax_domain)
+            if field_names:
+                tax["amount"] = sign * (getattr(fiscal_line, field_names[0]) or 0.0)
+                tax["base"] = sign * (getattr(fiscal_line, field_names[1]) or 0.0)
 
     @api.depends(
         "tax_ids",

--- a/l10n_br_account/models/account_move_line.py
+++ b/l10n_br_account/models/account_move_line.py
@@ -411,13 +411,13 @@ class AccountMoveLine(models.Model):
         override.
         """
         for tax in taxes:
-            acc_tax = self.env["account.tax"].browse(tax.get("id") or [])
-            if not acc_tax and tax.get("tax_repartition_line_id"):
-                acc_tax = (
-                    self.env["account.tax.repartition.line"]
-                    .browse(tax["tax_repartition_line_id"])
-                    .tax_id
-                )
+            repartition_line = self.env["account.tax.repartition.line"].browse(
+                tax.get("tax_repartition_line_id") or []
+            )
+            acc_tax = (
+                self.env["account.tax"].browse(tax.get("id") or [])
+                or repartition_line.tax_id
+            )
             fiscal_group = acc_tax.tax_group_id.fiscal_tax_group_id
             if fiscal_group.tax_withholding:
                 # Clear withholding taxes: XML doesn't bring WH item per item
@@ -426,7 +426,13 @@ class AccountMoveLine(models.Model):
                 continue
             field_names = self._IMPORTED_TAX_FIELD_MAP.get(fiscal_group.tax_domain)
             if field_names:
-                tax["amount"] = sign * (getattr(fiscal_line, field_names[0]) or 0.0)
+                # compute_all returns one entry per tax repartition line:
+                # each entry must carry only its share (factor) of the
+                # imported tax value, otherwise taxes with more than one
+                # repartition line would be counted multiple times.
+                factor = repartition_line.factor if repartition_line else 1.0
+                fiscal_value = getattr(fiscal_line, field_names[0]) or 0.0
+                tax["amount"] = sign * fiscal_value * factor
                 tax["base"] = sign * (getattr(fiscal_line, field_names[1]) or 0.0)
 
     @api.depends(

--- a/l10n_br_account_nfe/tests/test_nfe_import.py
+++ b/l10n_br_account_nfe/tests/test_nfe_import.py
@@ -168,14 +168,14 @@ class NFeImportTest(TransactionCase):
             move.document_key, "35231149647316000169550010000661061151600085"
         )
 
-        self.assertAlmostEqual(move.amount_price_gross, 11975.96)
-        self.assertAlmostEqual(move.amount_discount_value, 0)
-        self.assertAlmostEqual(move.amount_untaxed, 11975.96)
-        self.assertAlmostEqual(move.amount_freight_value, 0)
-        self.assertAlmostEqual(move.amount_insurance_value, 0)
-        self.assertAlmostEqual(move.amount_other_value, 0)
-        self.assertAlmostEqual(move.amount_tax, 251.90)
-        self.assertAlmostEqual(move.amount_total, 12227.86)
+        self.assertAlmostEqual(move.amount_price_gross, 11975.96, places=2)
+        self.assertAlmostEqual(move.amount_discount_value, 0, places=2)
+        self.assertAlmostEqual(move.amount_untaxed, 11975.96, places=2)
+        self.assertAlmostEqual(move.amount_freight_value, 0, places=2)
+        self.assertAlmostEqual(move.amount_insurance_value, 0, places=2)
+        self.assertAlmostEqual(move.amount_other_value, 0, places=2)
+        self.assertAlmostEqual(move.amount_tax, 251.90, places=2)
+        self.assertAlmostEqual(move.amount_total, 12227.86, places=2)
 
         self.assertEqual(len(move.invoice_line_ids), 4)
 
@@ -186,10 +186,12 @@ class NFeImportTest(TransactionCase):
         self.assertEqual(move.invoice_line_ids[0].product_id.code, "1070147")
         self.assertEqual(move.invoice_line_ids[0].product_id.ncm_id.code, "48111090")
         self.assertEqual(move.invoice_line_ids[0].quantity, 70.1)
-        self.assertAlmostEqual(move.invoice_line_ids[0].fiscal_quantity, 70.1)
-        self.assertAlmostEqual(move.invoice_line_ids[0].price_unit, 58.0)
-        self.assertAlmostEqual(move.invoice_line_ids[0].fiscal_price, 58.0)
-        self.assertAlmostEqual(move.invoice_line_ids[0].price_subtotal, 4065.80)
+        self.assertAlmostEqual(move.invoice_line_ids[0].fiscal_quantity, 70.1, places=2)
+        self.assertAlmostEqual(move.invoice_line_ids[0].price_unit, 58.0, places=2)
+        self.assertAlmostEqual(move.invoice_line_ids[0].fiscal_price, 58.0, places=2)
+        self.assertAlmostEqual(
+            move.invoice_line_ids[0].price_subtotal, 4065.80, places=2
+        )
         self.assertEqual(move.invoice_line_ids[0].nfe40_xPed, "OC00589")
         self.assertEqual(move.invoice_line_ids[0].product_uom_id.code, "KG")
 
@@ -197,17 +199,17 @@ class NFeImportTest(TransactionCase):
             move.invoice_line_ids[0].icms_tax_id.id,
             self.ref("l10n_br_fiscal.tax_icms_12"),
         )
-        self.assertAlmostEqual(move.invoice_line_ids[0].icms_value, 487.90)
+        self.assertAlmostEqual(move.invoice_line_ids[0].icms_value, 487.90, places=2)
         self.assertEqual(
             move.invoice_line_ids[0].ipi_tax_id.id,
             self.ref("l10n_br_fiscal.tax_ipi_3_25"),
         )
-        self.assertAlmostEqual(move.invoice_line_ids[0].ipi_value, 132.14)
+        self.assertAlmostEqual(move.invoice_line_ids[0].ipi_value, 132.14, places=2)
         self.assertEqual(
             move.invoice_line_ids[0].pis_tax_id.id,
             self.ref("l10n_br_fiscal.tax_pis_0_65"),
         )
-        self.assertAlmostEqual(move.invoice_line_ids[0].pis_value, 23.26)
+        self.assertAlmostEqual(move.invoice_line_ids[0].pis_value, 23.26, places=2)
         self.assertEqual(
             move.invoice_line_ids[0].cofins_tax_id.id,
             self.ref("l10n_br_fiscal.tax_cofins_3"),
@@ -219,11 +221,13 @@ class NFeImportTest(TransactionCase):
         self.assertEqual(move.invoice_line_ids[1].product_id.code, "B100618007170")
         self.assertEqual(move.invoice_line_ids[1].product_id.ncm_id.code, "34060000")
         self.assertEqual(move.invoice_line_ids[1].quantity, 60)
-        self.assertAlmostEqual(move.invoice_line_ids[1].fiscal_quantity, 60)
+        self.assertAlmostEqual(move.invoice_line_ids[1].fiscal_quantity, 60, places=2)
         self.assertEqual(move.invoice_line_ids[1].product_uom_id.code, "MILHEI")
-        self.assertAlmostEqual(move.invoice_line_ids[1].price_subtotal, 3439.20)
+        self.assertAlmostEqual(
+            move.invoice_line_ids[1].price_subtotal, 3439.20, places=2
+        )
 
         self.assertEqual(len(move.due_line_ids), 3)
-        self.assertAlmostEqual(move.due_line_ids[0].credit, 4075.95)
-        self.assertAlmostEqual(move.due_line_ids[1].credit, 4075.95)
-        self.assertAlmostEqual(move.due_line_ids[2].credit, 4075.96)
+        self.assertAlmostEqual(move.due_line_ids[0].credit, 4075.95, places=2)
+        self.assertAlmostEqual(move.due_line_ids[1].credit, 4075.95, places=2)
+        self.assertAlmostEqual(move.due_line_ids[2].credit, 4075.96, places=2)

--- a/l10n_br_account_nfe/tests/test_nfe_import.py
+++ b/l10n_br_account_nfe/tests/test_nfe_import.py
@@ -64,7 +64,6 @@ class NFeImportTest(TransactionCase):
         with Form(wizard) as import_form:
             import_form.file = base64.b64encode(file_content)
             import_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_compras")
-            # self.assertEqual(import_form.issuer_name, "FORNECEDER NFE DEMO LTDA")
             lines = import_form.imported_products_ids._records
         for line in lines:  # ensure testing consistency
             del line["id"]
@@ -155,6 +154,15 @@ class NFeImportTest(TransactionCase):
         action = wizard.action_import_and_open_move()
         move = self.env["account.move"].browse(action["res_id"])
 
+        self.assertEqual(move.partner_id.name, "FORNECEDER NFE DEMO LTDA")
+        self.assertEqual(move.partner_id.vat, "04.712.500/0001-07")
+        self.assertEqual(move.partner_id.l10n_br_ie_code, "078016350838")
+        self.assertEqual(
+            move.document_type_id, self.env.ref("l10n_br_fiscal.document_55")
+        )
+        self.assertEqual(
+            move.fiscal_operation_id, self.env.ref("l10n_br_fiscal.fo_compras")
+        )
         self.assertEqual(move.document_number, "66106")
         self.assertEqual(
             move.document_key, "35231149647316000169550010000661061151600085"

--- a/l10n_br_cte/models/document.py
+++ b/l10n_br_cte/models/document.py
@@ -1866,68 +1866,14 @@ class CTe(spec_models.StackedModel):
     def _add_ibscbs_line_attrs(self, binding, line_attrs):
         """Extract IBS/CBS values from the binding and update line_attrs."""
         ibscbs = getattr(binding.infCte.imp, "IBSCBS", None)
-        if not (ibscbs and ibscbs.gIBSCBS):
-            return
-
-        gibscbs = ibscbs.gIBSCBS
-        v_bc = float(gibscbs.vBC) if gibscbs.vBC else 0.0
-
-        ibs_percent = ibs_value = 0.0
-        if gibscbs.gIBSUF:
-            ibs_percent = float(gibscbs.gIBSUF.pIBSUF) if gibscbs.gIBSUF.pIBSUF else 0.0
-            ibs_value = float(gibscbs.gIBSUF.vIBSUF) if gibscbs.gIBSUF.vIBSUF else 0.0
-        cbs_percent = cbs_value = 0.0
-        if gibscbs.gCBS:
-            cbs_percent = float(gibscbs.gCBS.pCBS) if gibscbs.gCBS.pCBS else 0.0
-            cbs_value = float(gibscbs.gCBS.vCBS) if gibscbs.gCBS.vCBS else 0.0
-
-        cst_code = ibscbs.CST if ibscbs.CST else "000"
-        cst_ibs = self.env.ref(
-            f"l10n_br_fiscal.cst_ibs_{cst_code}", raise_if_not_found=False
+        tax_ids = self.env["l10n_br_fiscal.document.line"]._add_imported_ibscbs_vals(
+            ibscbs, line_attrs
         )
-        cst_cbs = self.env.ref(
-            f"l10n_br_fiscal.cst_cbs_{cst_code}", raise_if_not_found=False
-        )
-        ibs_tax = self.env["l10n_br_fiscal.tax"].search(
-            [
-                (
-                    "tax_group_id",
-                    "=",
-                    self.env.ref("l10n_br_fiscal.tax_group_ibs").id,
-                ),
-                ("percent_amount", "=", ibs_percent),
-            ],
-            limit=1,
-        )
-        cbs_tax = self.env["l10n_br_fiscal.tax"].search(
-            [
-                (
-                    "tax_group_id",
-                    "=",
-                    self.env.ref("l10n_br_fiscal.tax_group_cbs").id,
-                ),
-                ("percent_amount", "=", cbs_percent),
-            ],
-            limit=1,
-        )
-        fiscal_tax_ids = line_attrs.get("fiscal_tax_ids", [])
-        if ibs_tax:
-            line_attrs["ibs_tax_id"] = ibs_tax.id
-            fiscal_tax_ids += [Command.link(ibs_tax.id)]
-        if cbs_tax:
-            line_attrs["cbs_tax_id"] = cbs_tax.id
-            fiscal_tax_ids += [Command.link(cbs_tax.id)]
-        line_attrs["fiscal_tax_ids"] = fiscal_tax_ids
-        if cst_ibs:
-            line_attrs["ibs_cst_id"] = cst_ibs.id
-        if cst_cbs:
-            line_attrs["cbs_cst_id"] = cst_cbs.id
-        line_attrs["ibs_base"] = v_bc
-        line_attrs["ibs_percent"] = ibs_percent
-        line_attrs["ibs_value"] = ibs_value
-        line_attrs["cbs_base"] = v_bc
-        line_attrs["cbs_percent"] = cbs_percent
-        line_attrs["cbs_value"] = cbs_value
+        if tax_ids:
+            # line_attrs feed a Command.create(), so m2m needs commands
+            fiscal_tax_ids = line_attrs.get("fiscal_tax_ids", [])
+            fiscal_tax_ids += [Command.link(tax_id) for tax_id in tax_ids]
+            line_attrs["fiscal_tax_ids"] = fiscal_tax_ids
 
     def import_binding_cte(self, binding, edoc_type="in", dry_run=False):
         if hasattr(binding, "CTe"):

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -127,3 +127,72 @@ class DocumentLine(models.Model):
             line.additional_data = line.comment_ids.compute_message(
                 line.__document_comment_vals(), line.manual_additional_data
             )
+
+    @api.model
+    def _add_imported_ibscbs_vals(self, ibscbs, vals):
+        """Merge into ``vals`` the IBS/CBS values of an imported IBSCBS
+        binding node (NFe and CTe share the same DFe schema for it).
+
+        Returns the list of matched fiscal tax ids so each caller can
+        link them into ``fiscal_tax_ids`` with its own convention (the
+        NFe import framework expects raw ids, the CTe one expects
+        Command tuples).
+        """
+        tax_ids = []
+        if not (ibscbs and ibscbs.gIBSCBS):
+            return tax_ids
+
+        gibscbs = ibscbs.gIBSCBS
+        base = float(gibscbs.vBC) if gibscbs.vBC else 0.0
+
+        ibs_percent = ibs_value = 0.0
+        if gibscbs.gIBSUF:
+            ibs_percent = float(gibscbs.gIBSUF.pIBSUF) if gibscbs.gIBSUF.pIBSUF else 0.0
+            ibs_value = float(gibscbs.gIBSUF.vIBSUF) if gibscbs.gIBSUF.vIBSUF else 0.0
+        cbs_percent = cbs_value = 0.0
+        if gibscbs.gCBS:
+            cbs_percent = float(gibscbs.gCBS.pCBS) if gibscbs.gCBS.pCBS else 0.0
+            cbs_value = float(gibscbs.gCBS.vCBS) if gibscbs.gCBS.vCBS else 0.0
+
+        cst_code = ibscbs.CST if ibscbs.CST else "000"
+        cst_ibs = self.env.ref(
+            f"l10n_br_fiscal.cst_ibs_{cst_code}", raise_if_not_found=False
+        )
+        if cst_ibs:
+            vals["ibs_cst_id"] = cst_ibs.id
+        cst_cbs = self.env.ref(
+            f"l10n_br_fiscal.cst_cbs_{cst_code}", raise_if_not_found=False
+        )
+        if cst_cbs:
+            vals["cbs_cst_id"] = cst_cbs.id
+
+        vals.update(
+            ibs_base=base,
+            ibs_percent=ibs_percent,
+            ibs_value=ibs_value,
+            cbs_base=base,
+            cbs_percent=cbs_percent,
+            cbs_value=cbs_value,
+        )
+
+        ibs_tax = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_ibs").id),
+                ("percent_amount", "=", ibs_percent),
+            ],
+            limit=1,
+        )
+        if ibs_tax:
+            vals["ibs_tax_id"] = ibs_tax.id
+            tax_ids.append(ibs_tax.id)
+        cbs_tax = self.env["l10n_br_fiscal.tax"].search(
+            [
+                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_cbs").id),
+                ("percent_amount", "=", cbs_percent),
+            ],
+            limit=1,
+        )
+        if cbs_tax:
+            vals["cbs_tax_id"] = cbs_tax.id
+            tax_ids.append(cbs_tax.id)
+        return tax_ids

--- a/l10n_br_nfe/__init__.py
+++ b/l10n_br_nfe/__init__.py
@@ -1,21 +1,6 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-# Monkey-patch xsdata XmlContext to properly handle NFe namespace
-# for classes from dfe_tipos_basicos_v1_00 which don't declare it
-from xsdata.formats.dataclass.context import XmlContext
-
-_original_fetch = XmlContext.fetch
-
-
-def _patched_fetch(self, clazz, parent_ns=None, xsi_type=None):
-    if clazz.__module__ == "nfelib.nfe.bindings.v4_0.dfe_tipos_basicos_v1_00":
-        parent_ns = parent_ns or "http://www.portalfiscal.inf.br/nfe"
-    return _original_fetch(self, clazz, parent_ns, xsi_type)
-
-
-XmlContext.fetch = _patched_fetch
-
-from .hooks import post_init_hook  # noqa: E402
-from . import models  # noqa: E402
-from . import wizards  # noqa: E402
-from . import report  # noqa: E402
+from .hooks import post_init_hook
+from . import models
+from . import wizards
+from . import report

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -1651,76 +1651,14 @@ class NFeLine(spec_models.StackedModel):
 
     def _import_ibscbs_attrs(self, value, odoo_attrs):
         """Import IBSCBS tax attributes from NFe binding."""
-        if not value or not value.gIBSCBS:
-            return
-
-        gibscbs = value.gIBSCBS
-
-        # Base calculation
-        v_bc = float(gibscbs.vBC) if gibscbs.vBC else 0.0
-
-        # CST - shared for both IBS and CBS
-        cst_code = value.CST if value.CST else "000"
-        cst_ibs = self.env.ref(
-            f"l10n_br_fiscal.cst_ibs_{cst_code}", raise_if_not_found=False
+        tax_ids = self.env["l10n_br_fiscal.document.line"]._add_imported_ibscbs_vals(
+            value, odoo_attrs
         )
-        if cst_ibs:
-            odoo_attrs["ibs_cst_id"] = cst_ibs.id
-        cst_cbs = self.env.ref(
-            f"l10n_br_fiscal.cst_cbs_{cst_code}", raise_if_not_found=False
-        )
-        if cst_cbs:
-            odoo_attrs["cbs_cst_id"] = cst_cbs.id
-
-        # IBS values
-        ibs_percent = 0.0
-        ibs_value = 0.0
-        if gibscbs.gIBSUF:
-            ibs_percent = float(gibscbs.gIBSUF.pIBSUF) if gibscbs.gIBSUF.pIBSUF else 0.0
-            ibs_value = float(gibscbs.gIBSUF.vIBSUF) if gibscbs.gIBSUF.vIBSUF else 0.0
-
-        odoo_attrs["ibs_base"] = v_bc
-        odoo_attrs["ibs_percent"] = ibs_percent
-        odoo_attrs["ibs_value"] = ibs_value
-
-        # CBS values
-        cbs_percent = 0.0
-        cbs_value = 0.0
-        if gibscbs.gCBS:
-            cbs_percent = float(gibscbs.gCBS.pCBS) if gibscbs.gCBS.pCBS else 0.0
-            cbs_value = float(gibscbs.gCBS.vCBS) if gibscbs.gCBS.vCBS else 0.0
-
-        odoo_attrs["cbs_base"] = v_bc
-        odoo_attrs["cbs_percent"] = cbs_percent
-        odoo_attrs["cbs_value"] = cbs_value
-
-        # Find IBS tax
-        ibs_tax = self.env["l10n_br_fiscal.tax"].search(
-            [
-                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_ibs").id),
-                ("percent_amount", "=", ibs_percent),
-            ],
-            limit=1,
-        )
-        if ibs_tax:
-            odoo_attrs["ibs_tax_id"] = ibs_tax.id
+        if tax_ids:
+            # the NFe import framework links m2m fields with raw ids
             if not odoo_attrs.get("fiscal_tax_ids"):
                 odoo_attrs["fiscal_tax_ids"] = []
-            odoo_attrs["fiscal_tax_ids"].append(ibs_tax.id)
-
-        # Find CBS tax
-        cbs_tax = self.env["l10n_br_fiscal.tax"].search(
-            [
-                ("tax_group_id", "=", self.env.ref("l10n_br_fiscal.tax_group_cbs").id),
-                ("percent_amount", "=", cbs_percent),
-            ],
-            limit=1,
-        )
-        if cbs_tax:
-            odoo_attrs["cbs_tax_id"] = cbs_tax.id
-            if not odoo_attrs.get("fiscal_tax_ids"):
-                odoo_attrs["fiscal_tax_ids"] = []
-            odoo_attrs["fiscal_tax_ids"].append(cbs_tax.id)
+            odoo_attrs["fiscal_tax_ids"].extend(tax_ids)
 
     def _verify_related_many2ones(self, related_many2ones):
         if (

--- a/l10n_br_nfe/tests/test_nfe_import.py
+++ b/l10n_br_nfe/tests/test_nfe_import.py
@@ -137,7 +137,6 @@ class NFeImportTest(TransactionCase):
         self.assertTrue(shipping, "delivery address was not imported")
         self.assertNotEqual(shipping, nfe.partner_id)
         self.assertEqual(shipping.type, "delivery")
-        shipping._inverse_nfe40_CEP()
         self.assertEqual(shipping.street_name, "Rua da Entrega")
         self.assertEqual(shipping.zip, "01001-000")
 


### PR DESCRIPTION
Sugestões da revisão do OCA/l10n-brazil#4494, um commit por ponto — todos com os testes de import (`l10n_br_account_nfe`, `l10n_br_nfe`, `l10n_br_cte`) verdes localmente:

- `18fd419` [REF] resolve o imposto via `tax_group_id.fiscal_tax_group_id.tax_domain` (remove a heurística por nome)
- `cbb9d5a` [FIX] aplica o fator de repartição no override dos impostos importados
- `b86665e` [REF] guard no `_inverse_tax_totals` no lugar dos pops de `tax_totals` (por registro)
- `2a25d6c` [REF] remove o monkey-patch do xsdata — o fix de namespace já está no nfelib 2.5.x (akretion/nfelib#134/#151)
- `59b20a4` [REF] helper IBSCBS compartilhado NFe/CTe no `l10n_br_fiscal` (−63 linhas)
- `f874582` [REF] escreve os amounts importados uma vez só, na fiscal line
- `b91ab05` [REF] remove o `_compute_amount()` manual — os depends novos já disparam a recomputação
- `3219471` [FIX] restaura os asserts de partner/documento no teste de import (passam como estavam)
- `1ab300c` [IMP] `assertAlmostEqual` monetário com `places=2`
- `8b790f2` [REF] remove o inverse manual no teste de endereço de entrega (desnecessário)

O racional de cada ponto está nos comentários da revisão no OCA#4494. Fica à vontade pra descartar o que não concordar.